### PR TITLE
Example on explained variance to MDS2 and modified beta diversity text

### DIFF
--- a/14-microbiome-diversity.Rmd
+++ b/14-microbiome-diversity.Rmd
@@ -101,7 +101,17 @@ ggpubr::ggarrange(plotlist = plots, nrow = 2, ncol = 3, common.legend = TRUE, le
 
 Where alpha diversity focuses on community variation within a
 community (sample), beta diversity quantifies (dis-)similarites
-between communities (samples).
+between communities (samples). Some of the most popular beta diversity
+measures in microbiome research include Bray-Curtis index (for
+compositional data), Jaccard index (for presence / absence data,
+ignoring abundance information), Aitchison distance (Euclidean
+distance for clr transformed abundances, aiming to avoid the
+compositionality bias), and the Unifrac distances (that take into
+account the phylogenetic tree information). Only some of the commonly
+used beta diversity measures are actual _distances_; this is a
+mathematically well-defined concept and many ecological beta diversity
+measures, such as Bray-Curtis index, are not proper distances.
+Therefore, the term dissimilarity or beta diversity is commonly used.
 
 Technically, beta diversities are usually represented as `dist`
 objects, which contain triangular data describing the distance between
@@ -122,10 +132,81 @@ multi-dimensional scaling (MDS, NMDS), The MDS methods is also known
 as Principal Coordinates Analysis (PCoA). Other recently popular
 techniques include t-SNE and UMAP. 
 
-Some of the above-mentioned ordination methods (PCA, MDS/PCoA) allow
-the estimation of explained variance in the data for each ordination
-axis; this is informative to show in the figures when it is defined
-and available.
+
+### Explained variance
+
+The percentage of explained variance is typically shown for PCA
+ordination plots. This quantifies the proportion of overall variance
+in the data that is captured by the PCA axes, or how well the
+ordination axes reflect the original distances.
+
+Sometimes a similar measure is shown for MDS/PCoA. The interpretation
+is generally different, however, and hence we do not recommend using
+it. PCA is a special case of PCoA with Euclidean distances.  With
+non-Euclidean dissimilarities PCoA uses a trick where the pointwise
+dissimilarities are first cast into similarities a Euclidean space
+(with some information loss i.e. stress) and then projected to the
+maximal variance axes. In this case, the maximal variance axes do not
+directly reflect the correspondence of the projected distances and
+original distances, as they do for PCA.
+
+In typical use cases, we would like to know how well the ordination
+reflects the original similarity structures; then the quantity of
+interest is the so-called "stress" function, which measures the
+difference in pairwise similarities between the data points in the
+original (high-dimensional) vs. projected (low-dimensional) space.
+
+Hence, we propose that for PCoA and other ordination methods, users
+would report relative stress (varies in the unit interval; the smaller
+the better). This can be calculated as shown below. For further
+examples, check the [note from Huber
+lab](https://www.huber.embl.de/users/klaus/Teaching/statisticalMethods-lab.pdf).
+
+
+```{r relstress}
+# Example data
+data(GlobalPatterns)
+
+# Data matrix (features x samples)
+x <- GlobalPatterns
+x <- transformCounts(x, method = "relabundance")
+x <- assay(x, "relabundance")
+
+# Quantify dissimilarities in the original feature space
+library(vegan)
+d0 <- as.matrix(vegdist(t(x), "bray"))
+
+# PCoA Ordination
+pcoa <- as.data.frame(cmdscale(d0, k = 2))
+names(pcoa) <- c("PCoA1", "PCoA2")
+
+# Quantify dissimilarities in the ordination space
+dp <- as.matrix(dist(pcoa))
+
+# Calculate stress i.e. relative difference in the original and
+# projected dissimilarities
+stress <- sum((dp - d0)^2)/sum(d0^2)
+```
+
+
+Shepard plot visualizes the original versus projected (ordination)
+dissimilarities between the data points:
+
+```{r shepard}
+ord <- order(as.vector(d0))
+df <- data.frame(d0 = as.vector(d0)[ord],
+                  dmds = as.vector(dp)[ord])
+
+library(ggplot2)
+ggplot(aes(x = d0, y = dmds), data=df) + 
+       geom_smooth() +
+       geom_point() +       
+       labs(title = "Shepard plot",
+       x = "Original distance",
+       y = "MDS distance",       
+            subtitle = paste("Stress:", round(stress, 2)))
+```
+
 
 
 
@@ -140,7 +221,7 @@ or NMDS), and the results can be stored in the `reducedDim`.
 This entire process is wrapped in the `runMDS` and `runNMDS`
 functions.
 
-```{r, message=FALSE}
+```{r runMDS, message=FALSE}
 se <- runMDS(se, FUN = vegan::vegdist, name = "MDS_BC", exprs_values = "counts")
 ```
 


### PR DESCRIPTION
Percent of explained variance is commonly shown for PCA and MDS/PCoA, and I added now an example to MiaBook.

The explained variance is not properly defined for methods such as NMSD, t-SNE or UMAP and cannot be added in the same way unless someone comes up with a proper, unambiguous alternative definition for these (which I am not sure is possible to do due to the mathematical differences).

We can discuss in the PR comments on possible improvements to this workflow.


