### PR TITLE
makeTSEFromphy --> makeTSEFromPhy

### DIFF
--- a/01_introduction.Rmd
+++ b/01_introduction.Rmd
@@ -292,7 +292,7 @@ data(GlobalPatterns, package="phyloseq")
 GlobalPatterns_phyloseq <- GlobalPatterns
 
 # convert phyloseq to TSE
-GlobalPatterns_TSE <- makeTreeSummarizedExperimentFromphyloseq(GlobalPatterns_phyloseq) 
+GlobalPatterns_TSE <- makeTreeSummarizedExperimentFromPhyloseq(GlobalPatterns_phyloseq) 
 ```
 
 


### PR DESCRIPTION
Hi,

because the name of `makeTSEFromphy` will be changed to `makeTSEFromPhy` (PR: https://github.com/microbiome/mia/pull/119), function name is corrected. 

Issue: https://github.com/microbiome/mia/issues/117

-Tuomas