### PR TITLE
Bookstyle change

### DIFF
--- a/01_introduction.Rmd
+++ b/01_introduction.Rmd
@@ -1,4 +1,4 @@
-# (PART) Introduction {-}
+
 
 # Data Infrastructure {#data-introduction}
 

--- a/10_overview.Rmd
+++ b/10_overview.Rmd
@@ -1,4 +1,3 @@
-# (PART) Focus Topics {-}
 
 # Overview
 

--- a/90_example_data.Rmd
+++ b/90_example_data.Rmd
@@ -1,4 +1,4 @@
-# (PART) Appendix {-}
+
 
 # Example Data {#example-data}
 

--- a/98_function_reference.Rmd
+++ b/98_function_reference.Rmd
@@ -1,4 +1,4 @@
-# (PART) Appendix {-}
+
 
 # Function Reference {#function-ref}
 

--- a/99_interactive_3d_plots.Rmd
+++ b/99_interactive_3d_plots.Rmd
@@ -1,4 +1,4 @@
-# (PART) Appendix {-}
+
 
 # Extras {#extras}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Suggests:
     tibble,
     TreeSummarizedExperiment,
     uwot,
-    phyloseq
+    phyloseq,
+    msmbstyle
 Remotes:
     github::microbiome/mia,
     github::microbiome/miaViz

--- a/_output.yml
+++ b/_output.yml
@@ -1,4 +1,4 @@
-bookdown::gitbook:
+msmbstyle::msmb_html_book:
   css: style.css
   config:
     fontsettings:


### PR DESCRIPTION
Hi,

this changes the book style to `msmbstyle`. You can render it, e.g., with `bookdown::serve_book()`
This is not completely working yet, for instance, there is problem with table of contents. I wanted to hear you opinion before I use more time to fix this thing. 

Personally, I think that current book style is better. It is more clear and user can easily find what he/she is looking for because toc is always visible. In addition to that, I think that `msmbstyle` doesn't have those "download pdf" and "share" icons (currently we don't have pdf version, but we could easily add it).

Any thoughts?

Issue: https://github.com/microbiome/OMA/issues/21

-Tuomas