### PR TITLE
Added front page figure

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -49,3 +49,17 @@ knitr::opts_chunk$set(
   dpi=300
 )
 ```
+
+```{js, echo = FALSE}
+// This block adds image to the front page
+title=document.getElementById('header');
+title.innerHTML = title.innerHTML + 
+
+'<img src="https://user-images.githubusercontent.com/60338854/121848694-\
+1072a480-ccf3-11eb-9af2-7fdefd8d1794.png" alt="ML4microbiome" width="50%"/>' +
+
+'<p style="font-size:12px">Figure source: Moreno-Indias _et al_. (2021) \
+<a href="https://doi.org/10.3389/fmicb.2021.635781">Statistical and \
+Machine Learning Techniques in Human Microbiome Studies: Contemporary \
+Challenges and Solutions</a>. Frontiers in Microbiology 12:11.</p>'
+```

--- a/index.Rmd
+++ b/index.Rmd
@@ -58,7 +58,7 @@ title.innerHTML = title.innerHTML +
 '<img src="https://user-images.githubusercontent.com/60338854/128359392\
 -6feef8df-30e9-4ea0-ae3b-4bb619d746ed.png" alt="Microbiome" width="50%"/>' +
 
-'<p style="font-size:12px">Figure source: Moreno-Indias _et al_. (2021) \
+'<p style="font-size:12px">Figure source: Moreno-Indias <i>et al</i>. (2021) \
 <a href="https://doi.org/10.3389/fmicb.2021.635781">Statistical and \
 Machine Learning Techniques in Human Microbiome Studies: Contemporary \
 Challenges and Solutions</a>. Frontiers in Microbiology 12:11.</p>'

--- a/index.Rmd
+++ b/index.Rmd
@@ -55,8 +55,8 @@ knitr::opts_chunk$set(
 title=document.getElementById('header');
 title.innerHTML = title.innerHTML + 
 
-'<img src="https://user-images.githubusercontent.com/60338854/121848694-\
-1072a480-ccf3-11eb-9af2-7fdefd8d1794.png" alt="ML4microbiome" width="50%"/>' +
+'<img src="https://user-images.githubusercontent.com/60338854/128359392\
+-6feef8df-30e9-4ea0-ae3b-4bb619d746ed.png" alt="Microbiome" width="50%"/>' +
 
 '<p style="font-size:12px">Figure source: Moreno-Indias _et al_. (2021) \
 <a href="https://doi.org/10.3389/fmicb.2021.635781">Statistical and \


### PR DESCRIPTION
Hi,

I like Leo's idea of front page figure so I implemented it. 

Here are two different versions, another has figure before title and another after. Which is better? I think after is better, and in this current implementation it is after. 

Any thoughts from others, should we add this?

Before:
![image](https://user-images.githubusercontent.com/60338854/128342268-70c6de3f-f822-4812-9a1a-4f0fa2bb111e.png)

After (current implementation):
![image](https://user-images.githubusercontent.com/60338854/128342284-17f9b3ac-9a04-4238-a2c8-b5fa5f1bbeca.png)

Issue: https://github.com/microbiome/OMA/issues/63

-Tuomas