### PR TITLE
Resources fix

### DIFF
--- a/95_resources.Rmd
+++ b/95_resources.Rmd
@@ -16,17 +16,17 @@ chapterPreamble()
 
 ### Resources for TreeSummarizedExperiment
 
- * SingleCellExperiment
-   + [@R-R-SingleCellExperiment]
-   + [Online tutorial](https://bioconductor.org/packages/release/bioc/vignettes/SingleCellExperiment/inst/doc/intro.html)
+ * SingleCellExperiment [@R-SingleCellExperiment]
+   + [Online tutorial](https://bioconductor.org/packages/release/bioc/vignettes/
+   SingleCellExperiment/inst/doc/intro.html)
    + [Project page](https://bioconductor.org/packages/release/bioc/html/SingleCellExperiment.html)
- * SummarizedExperiment
-   + [@R-SummarizedExperiment]
-   + [Online tutorial](https://bioconductor.org/packages/release/bioc/vignettes/SummarizedExperiment/inst/doc/SummarizedExperiment.html)
+ * SummarizedExperiment [@R-SummarizedExperiment]
+   + [Online tutorial](https://bioconductor.org/packages/release/bioc/vignettes/
+   SummarizedExperiment/inst/doc/SummarizedExperiment.html)
    + [Project page](https://bioconductor.org/packages/release/bioc/html/SummarizedExperiment.html)
- * TreeSummarizedExperiment
-   + [@R-TreeSummarizedExperiment]
-   + [Online tutorial](https://bioconductor.org/packages/release/bioc/vignettes/TreeSummarizedExperiment/inst/doc/Introduction_to_treeSummarizedExperiment.html)
+ * TreeSummarizedExperiment [@R-TreeSummarizedExperiment]
+   + [Online tutorial](https://bioconductor.org/packages/release/bioc/vignettes/
+   TreeSummarizedExperiment/inst/doc/Introduction_to_treeSummarizedExperiment.html)
    + [Project page](https://www.bioconductor.org/packages/release/bioc/html/TreeSummarizedExperiment.html)
    
 

--- a/95_resources.Rmd
+++ b/95_resources.Rmd
@@ -17,14 +17,18 @@ chapterPreamble()
 ### Resources for TreeSummarizedExperiment
 
  * SingleCellExperiment
-   + [Publication](https://bioconductor.org/packages/release/bioc/vignettes/SingleCellExperiment/inst/doc/intro.html)
+   + [@R-R-SingleCellExperiment]
+   + [Online tutorial](https://bioconductor.org/packages/release/bioc/vignettes/SingleCellExperiment/inst/doc/intro.html)
    + [Project page](https://bioconductor.org/packages/release/bioc/html/SingleCellExperiment.html)
  * SummarizedExperiment
-   + [Publication](https://bioconductor.org/packages/release/bioc/vignettes/SummarizedExperiment/inst/doc/SummarizedExperiment.html)
+   + [@R-SummarizedExperiment]
+   + [Online tutorial](https://bioconductor.org/packages/release/bioc/vignettes/SummarizedExperiment/inst/doc/SummarizedExperiment.html)
    + [Project page](https://bioconductor.org/packages/release/bioc/html/SummarizedExperiment.html)
  * TreeSummarizedExperiment
-   + [Publication](https://f1000research.com/articles/9-1246)
+   + [@R-TreeSummarizedExperiment]
+   + [Online tutorial](https://bioconductor.org/packages/release/bioc/vignettes/TreeSummarizedExperiment/inst/doc/Introduction_to_treeSummarizedExperiment.html)
    + [Project page](https://www.bioconductor.org/packages/release/bioc/html/TreeSummarizedExperiment.html)
+   
 
 ### Other relevant containers
 


### PR DESCRIPTION
Hi,

vignettes are listed as "online tutorials", and publications are cited using citation from book.bib

Does this look fine?

Issue: https://github.com/microbiome/OMA/issues/97

![image](https://user-images.githubusercontent.com/60338854/143568841-97cb61e6-bec5-4fd0-80bf-edb23dd4e426.png)


-Tuomas