### PR TITLE
Fix broken link in section on beta diversity

### DIFF
--- a/20_beta_diversity.Rmd
+++ b/20_beta_diversity.Rmd
@@ -405,7 +405,7 @@ appropriate choice for comparing community compositions.
 
  - [How to extract information from clusters](http://bioconductor.org/books/release/OSCA/clustering.html)
 
- - [Community typing](15-microbiome-community.md)
+ - [Community typing](21_microbiome_community.md)
 
 
 ## Session Info {-}


### PR DESCRIPTION
A link to the section on community typing was broken.