### PR TITLE
Introduce section on Faith index

### DIFF
--- a/14_alpha_diversity.Rmd
+++ b/14_alpha_diversity.Rmd
@@ -199,6 +199,26 @@ tse <- mia::estimateDiversity(tse,
 head(colData(tse)$log_modulo_skewness)
 ```
 
+### Faith phylogenetic diversity
+
+Unlike other indices, the Faith index is not based on the richness and/or evenness of a community. Instead, it measures the alpha diversity by the aid of the phylogenetic distance among species. It is returned by the function `estimateFaith`.
+
+```{r}
+tse <- mia::estimateFaith(tse,
+                          abund_values = "counts")
+```
+
+**Note**: because `tse` is a `TreeSummarizedExperiment` object, its phylogenetic tree is used by default. However, the optional argument `tree` must be provided if `tse` does not contain one.
+
+Below a visual comparison between shannon and faith indices is shown with a violin plot.
+
+```{r}
+plots <- lapply(c("shannon", "faith"),
+                plotColData,
+                object = tse)
+ggpubr::ggarrange(plotlist = plots, nrow = 1, ncol = 2)
+```
+
 
 ## Visualization
 

--- a/14_alpha_diversity.Rmd
+++ b/14_alpha_diversity.Rmd
@@ -146,20 +146,37 @@ ggplot(df, aes(x = SampleType, y = shannon)) +
   theme(text = element_text(size = 10))
 ```
 
-**Phylogenetic diversity**  
+### Faith phylogenetic diversity
 
-The phylogenetic diversity is calculated by `mia::estimateDiversity`. This is a faster re-implementation of   
+The Faith index is returned by the function `estimateFaith`.
+
+```{r phylo-div-1}
+tse <- mia::estimateFaith(tse,
+                          abund_values = "counts")
+head(colData(tse)$faith)
+```
+
+**Note**: because `tse` is a `TreeSummarizedExperiment` object, its phylogenetic tree is used by default. However, the optional argument `tree` must be provided if `tse` does not contain one.
+
+Below a visual comparison between shannon and faith indices is shown with a violin plot.
+
+```{r phylo-div-2}
+plots <- lapply(c("shannon", "faith"),
+                plotColData,
+                object = tse)
+ggpubr::ggarrange(plotlist = plots, nrow = 1, ncol = 2)
+```
+ 
+Alternatively, the phylogenetic diversity can be calculated by `mia::estimateDiversity`. This is a faster re-implementation of   
 the widely used function in _`picante`_ [@R-picante, @Kembel2010].  
 
-Load `picante` R package and get the `phylo` stored in `rowTree`. 
-```{r phylo-div-1}
+Load `picante` R package and get the `phylo` stored in `rowTree`.
 
+```{r phylo-div-3}
 tse <- mia::estimateDiversity(tse, 
                               abund_values = "counts",
                               index = "faith", 
                               name = "faith")
-head(colData(tse)$faith)
-
 ```
 
 ### Evenness  
@@ -199,30 +216,10 @@ tse <- mia::estimateDiversity(tse,
 head(colData(tse)$log_modulo_skewness)
 ```
 
-### Faith phylogenetic diversity
-
-Unlike other indices, the Faith index is not based on the richness and/or evenness of a community. Instead, it measures the alpha diversity by the aid of the phylogenetic distance among species. It is returned by the function `estimateFaith`.
-
-```{r}
-tse <- mia::estimateFaith(tse,
-                          abund_values = "counts")
-```
-
-**Note**: because `tse` is a `TreeSummarizedExperiment` object, its phylogenetic tree is used by default. However, the optional argument `tree` must be provided if `tse` does not contain one.
-
-Below a visual comparison between shannon and faith indices is shown with a violin plot.
-
-```{r}
-plots <- lapply(c("shannon", "faith"),
-                plotColData,
-                object = tse)
-ggpubr::ggarrange(plotlist = plots, nrow = 1, ncol = 2)
-```
-
-
 ## Visualization
 
-A plot comparing all the diversity measures calculated above and stored in `colData` can then be constructed directly.  
+A plot comparing all the diversity measures calculated above and stored in `colData` can then be constructed directly.
+
 ```{r plot-all-diversities}
 plots <- lapply(c("observed", "shannon","simpson", "relative", "faith","log_modulo_skewness"),
                 plotColData,


### PR DESCRIPTION
The Faith phylogenetic diversity was previously covered in the [section about diversity](https://github.com/microbiome/OMA/blob/RiboRings/14_alpha_diversity.Rmd) in general (lines 149 - 163). That section is still there, before merging it is a good idea to combine that with the new material I added.