### PR TITLE
multi-panel plots to patchwork

### DIFF
--- a/14_alpha_diversity.Rmd
+++ b/14_alpha_diversity.Rmd
@@ -123,6 +123,7 @@ if( !require(ggsignif) ){
   install.packages(ggsignif)
 }
 library(ggplot2)
+library(patchwork)
 library(ggsignif)
 
 # Subsets the data. Takes only those samples that are from feces, skin, or tongue,
@@ -164,7 +165,7 @@ Below a visual comparison between shannon and faith indices is shown with a viol
 plots <- lapply(c("shannon", "faith"),
                 plotColData,
                 object = tse)
-ggpubr::ggarrange(plotlist = plots, nrow = 1, ncol = 2)
+plots[[1]] + plots[[2]]
 ```
  
 Alternatively, the phylogenetic diversity can be calculated by `mia::estimateDiversity`. This is a faster re-implementation of   
@@ -221,14 +222,20 @@ head(colData(tse)$log_modulo_skewness)
 A plot comparing all the diversity measures calculated above and stored in `colData` can then be constructed directly.
 
 ```{r plot-all-diversities}
-plots <- lapply(c("observed", "shannon","simpson", "relative", "faith","log_modulo_skewness"),
+plots <- lapply(c("observed", "shannon", "simpson", "relative", "faith", "log_modulo_skewness"),
                 plotColData,
                 object = tse,
                 x = "SampleType",
                 colour_by = "SampleType")
 
-plots <- lapply(plots,"+", theme(axis.text.x = element_text(angle=45,hjust=1)))
-ggpubr::ggarrange(plotlist = plots, nrow = 2, ncol = 3, common.legend = TRUE, legend = "right")
+plots <- lapply(plots, "+", 
+                theme(axis.text.x = element_blank(),
+                      axis.title.x = element_blank(),
+                      axis.ticks.x = element_blank()))
+
+((plots[[1]] | plots[[2]] | plots[[3]]) / 
+(plots[[4]] | plots[[5]] | plots[[6]])) +
+  plot_layout(guides = "collect")
 ```
 
 ## Session Info {-}

--- a/20_beta_diversity.Rmd
+++ b/20_beta_diversity.Rmd
@@ -185,11 +185,14 @@ tse <- runMDS(tse, FUN = vegan::vegdist, name = "MDS_euclidean",
 tse <- runNMDS(tse, FUN = vegan::vegdist, name = "NMDS_BC")
 tse <- runNMDS(tse, FUN = vegan::vegdist, name = "NMDS_euclidean",
                method = "euclidean")
-plots <- lapply(c("PCoA_BC","MDS_euclidean","NMDS_BC","NMDS_euclidean"),
-                plotReducedDim, object = tse, colour_by = "Group")
-ggpubr::ggarrange(plotlist = plots, nrow = 2, ncol = 2, common.legend = TRUE,
-                  legend = "right")
+plots <- lapply(c("PCoA_BC", "MDS_euclidean", "NMDS_BC", "NMDS_euclidean"),
+                plotReducedDim,
+                object = tse,
+                colour_by = "Group")
 
+library(patchwork)
+plots[[1]] + plots[[2]] + plots[[3]] + plots[[4]] +
+  plot_layout(guides = "collect")
 ```
 
 The _Unifrac_ method is a special case, as it requires data on the

--- a/24_biclustering.Rmd
+++ b/24_biclustering.Rmd
@@ -116,19 +116,23 @@ if(!require(ggplot2)){
     install.packages("ggplot2")
     library(ggplot2)
 }
-if(!require(gridExtra)){
-    install.packages("gridExtra")
-    library(gridExtra)
+if(!require(patchwork)){
+    install.packages("patchwork")
+    library(patchwork)
 }
 
 # ggplot requires data in melted format
 melt_assay <- meltAssay(mae[[1]], abund_values = "clr", add_col_data = T, add_row_data = T)
 
-# Use grid.arrange to arrange two plots side-by-side
-grid.arrange(
-ggplot(melt_assay) + geom_boxplot(aes(x = clusters.x, y = clr)) + labs(x = "Taxa clusters"),
-ggplot(melt_assay) + geom_boxplot(aes(x = clusters.y, y = clr)) + labs(x = "Sample clusters"),
-nrow = 1)
+# patchwork two plots side-by-side
+p1 <- ggplot(melt_assay) +
+  geom_boxplot(aes(x = clusters.x, y = clr)) +
+  labs(x = "Taxa clusters")
+p2 <- ggplot(melt_assay) +
+  geom_boxplot(aes(x = clusters.y, y = clr)) +
+  labs(x = "Sample clusters")
+
+p1 + p2
 ```
 
 ## Taxa vs biomolecules
@@ -291,8 +295,7 @@ for( data in df ){
     labs(title = paste0("Cluster ", i), x = "Taxa (clr median)", y = "Metabolites (abs. median)")
 }
 
-do.call(grid.arrange, c(plot_list, nrow = 1))
-
+plot_list[[1]] + plot_list[[2]] + plot_list[[3]]
 ```
 
 _pheatmap_ does not allow boolean values, so they must be converted into factors.

--- a/add-comm-typing.Rmd
+++ b/add-comm-typing.Rmd
@@ -181,7 +181,7 @@ Let's take a look at the MDS ordination with the Bray-Curtis dissimilarity in th
 ```{r message = FALSE, warning = FALSE}
 library(scater)
 library(RColorBrewer)
-library(cowplot)
+library(patchwork)
 
 # set up colours
 CSTColors <- brewer.pal(6, "Paired")[c(2, 5, 3, 4, 1, 6)]
@@ -198,7 +198,7 @@ p1 <- scater::plotReducedDim(tse2, "MDS_BC", colour_by = "CST", point_alpha = 1,
 p2 <- scater::plotReducedDim(tse2, "MDS_BC", colour_by = "CST", point_alpha = 1, 
                              ncomponents = c(3, 4), percentVar = var[c(1, 2, 3, 4)]*100) + th
 # show results
-plot_grid(p1 + CSTColorScale, p2 + CSTColorScale, nrow = 2)
+(p1 + CSTColorScale) / (p2 + CSTColorScale)
 ```
 
 And now nMDS.

--- a/book.bib
+++ b/book.bib
@@ -869,3 +869,11 @@ Bioconductor},
   langid = {english},
   file = {/Users/henrikeckermann/Zotero/storage/D59QN8JL/Sprockett et al. - 2020 - Microbiota assembly, structure, and dynamics among.pdf}
 }
+
+@Manual{patchwork2022,
+    title = {patchwork: The Composer of Plots},
+    author = {Thomas Lin Pedersen},
+    year = {2022},
+    note = {https://patchwork.data-imaginist.com,
+https://github.com/thomasp85/patchwork},
+  }


### PR DESCRIPTION
All multipanel plots are now generated with `patchwork` in place of other packages. They are equivalent to the previous plots (with the exception mentioned below).

In addition, a plot in the alpha diversity section was simplified because it contained some redundant information (the SampleType was encoded both as colour and x axis).

The bibtex reference to the package was also included in the tex file.