### PR TITLE
var expl. + p-val from --> anova.cca

### DIFF
--- a/20_beta_diversity.Rmd
+++ b/20_beta_diversity.Rmd
@@ -285,40 +285,29 @@ coldata <- colData(enterotype)
 # Create a formula
 formula <- as.formula(paste0("assay ~ ", str_c(variable_names, collapse = " + ")) )
 
-# # Perform RDA
+# Perform RDA
 rda <- rda(formula, data = coldata, scale = TRUE, na.action = na.exclude)
 
-# Initialize list for p-values
-rda_info <- list()
-# Name for storing the result
-variable_name <- "all"
-# Calculate and store p-value, and other information
-rda_info[[variable_name]] <- c(constrained = rda$CCA$tot.chi, 
-                               unconstrainded = rda$CA$tot.chi, 
-                               proportion = rda$CCA$tot.chi/rda$CA$tot.chi, 
-                               p_value = anova.cca(rda)["Model", "Pr(>F)"] )
-
-# Loop through variables
+# retrieving variances explained and p-values for the whole model and for each variable
 permutations <- 999
-for( variable_name in variable_names ){
-    # Create a formula
-    formula <- as.formula(paste0("assay ~ ", variable_name) )
-    # Perform RDA
-    rda_temp <- rda(formula, data = coldata, scale = TRUE, na.action = na.exclude)
-    # Add Info to list
-    rda_info[[variable_name]] <- c(constrained = rda_temp$CCA$tot.chi, 
-                                   unconstrainded = rda_temp$CA$tot.chi, 
-                                   proportion = rda_temp$CCA$tot.chi/rda$CA$tot.chi, 
-                                   p_value = anova.cca(rda_temp, permutations = permutations
-                                                       )["Model", "Pr(>F)"] )
-}  
-# Convert into data.frame
-rda_info <- t(as.data.frame(rda_info))
-rda_info_clean <- rda_info
+set.seed(123)
+rda_info <- anova.cca(rda, by="margin", permutations = permutations) %>% 
+    as.data.frame()
+
+# gathering info needed
+rda_info_clean <- data.frame(
+    round(rda_info$Variance[1:3], 4),
+    round(rda_info$Variance[1:3]/rda_info$Variance[4], 4),
+    rda_info$`Pr(>F)`[1:3],
+    check.names=FALSE, row.names = variable_names
+)
+
 # Adjust names
 colnames(rda_info_clean) <- 
-    c("Explained by variables", "Unexplained by variables", "Proportion expl by vars", 
+    c(paste0("Explained by variables (out of ",round(rda_info$Variance[4],4)," unexplained)"),
+      "Proportion expl by vars", 
       paste0("P-value (PERMANOVA ", permutations, " permutations)") )
+
 # Print info
 kable(rda_info_clean)
 ```
@@ -361,9 +350,9 @@ vec_lab <- sapply(vec_lab_old, FUN = function(name){
     }
     # Add percentage how much this variable explains, and p-value
     new_name <- expr(paste(!!new_name, " (", 
-                           !!format(round( rda_info[variable_name, "proportion"]*100, 1), nsmall = 1), 
+                           !!format(round( rda_info_clean[variable_name, 2]*100, 1), nsmall = 1), 
                            "%, ",italic("P"), " = ", 
-                           !!gsub("0\\.","\\.", format(round( rda_info[variable_name, "p_value"], 3), 
+                           !!gsub("0\\.","\\.", format(round( rda_info_clean[variable_name, 3], 3), 
                                                        nsmall = 3)), ")"))
 
     return(new_name)

--- a/20_beta_diversity.Rmd
+++ b/20_beta_diversity.Rmd
@@ -277,39 +277,67 @@ variable_names <- c("ClinicalStatus", "Gender", "Age")
 # Apply relative transform
 enterotype <- transformSamples(enterotype, method = "relabundance")
 
-# Get assay
-assay <- t(assay(enterotype, "relabundance"))
-# Get colData
-coldata <- colData(enterotype)
-
 # Create a formula
 formula <- as.formula(paste0("assay ~ ", str_c(variable_names, collapse = " + ")) )
 
-# Perform RDA
-rda <- rda(formula, data = coldata, scale = TRUE, na.action = na.exclude)
+# # Perform RDA
+rda <- calculateRDA(enterotype, assay_name = "relabundance",
+                    formula = formula, distance = "bray", na.action = na.exclude)
+# Get the rda object
+rda <- attr(rda, "rda")
+# Calculate p-value and variance for whole model
+# Recommendation: use 999 permutations instead of 99
+set.seed(436)
+permanova <- anova.cca(rda, permutations = 99)
+# Create a data.frame for results
+rda_info <- as.data.frame(permanova)["Model", ]
 
-# retrieving variances explained and p-values for the whole model and for each variable
-permutations <- 999
-set.seed(123)
-rda_info <- anova.cca(rda, by="margin", permutations = permutations) %>% 
-    as.data.frame()
+# Calculate p-value and variance for each variable
+# by = "margin" --> the order or variables does not matter
+set.seed(4585)
+permanova <- anova.cca(rda, by = "margin",  permutations = 99)
+# Add results to data.frame
+rda_info <- rbind(rda_info, permanova)
 
-# gathering info needed
-rda_info_clean <- data.frame(
-    round(rda_info$Variance[1:3], 4),
-    round(rda_info$Variance[1:3]/rda_info$Variance[4], 4),
-    rda_info$`Pr(>F)`[1:3],
-    check.names=FALSE, row.names = variable_names
-)
+# Add info about total variance
+rda_info[ , "Total variance"] <- rda_info["Model", 2] +
+    rda_info["Residual", 2]
 
-# Adjust names
-colnames(rda_info_clean) <- 
-    c(paste0("Explained by variables (out of ",round(rda_info$Variance[4],4)," unexplained)"),
-      "Proportion expl by vars", 
-      paste0("P-value (PERMANOVA ", permutations, " permutations)") )
+# Add info about explained variance
+rda_info[ , "Explained variance"] <- rda_info[ , 2] / 
+    rda_info[ , "Total variance"]
 
-# Print info
-kable(rda_info_clean)
+# Loop through variables, calculate homogeneity
+homogeneity <- list()
+# Get colDtaa
+coldata <- colData(enterotype)
+# Get assay
+assay <- t(assay(enterotype, "relabundance"))
+for( variable_name in rownames(rda_info) ){
+    # If data is continuous or discrete
+    if( variable_name %in% c("Model", "Residual") ||
+        length(unique(coldata[[variable_name]])) /
+        length(coldata[[variable_name]]) > 0.2 ){
+        # Do not calculate homogeneity for continuous data
+        temp <- NA
+    } else{
+        # Calculate homogeneity for discrete data
+        # Calculate homogeneity
+        set.seed(413)
+        temp <- anova(
+            betadisper( 
+                vegdist(assay, method = "bray"),
+                group = coldata[[variable_name]] ),
+            permutations = permutations )["Groups", "Pr(>F)"]
+    }
+    # Add info to the list
+    homogeneity[[variable_name]] <- temp
+}
+# Add homogeneity to information
+rda_info[["Homogeneity p-value (NULL hyp: distinct/homogeneous --> permanova suitable)"]] <-
+    homogeneity
+
+kable(rda_info)
 ```
 
 ```{r microbiome_RDA2}
@@ -350,9 +378,9 @@ vec_lab <- sapply(vec_lab_old, FUN = function(name){
     }
     # Add percentage how much this variable explains, and p-value
     new_name <- expr(paste(!!new_name, " (", 
-                           !!format(round( rda_info_clean[variable_name, 2]*100, 1), nsmall = 1), 
+                           !!format(round( rda_info[variable_name, "Explained variance"]*100, 1), nsmall = 1), 
                            "%, ",italic("P"), " = ", 
-                           !!gsub("0\\.","\\.", format(round( rda_info_clean[variable_name, 3], 3), 
+                           !!gsub("0\\.","\\.", format(round( rda_info[variable_name, "Pr(>F)"], 3), 
                                                        nsmall = 3)), ")"))
 
     return(new_name)

--- a/23_multi-assay_analyses.Rmd
+++ b/23_multi-assay_analyses.Rmd
@@ -145,20 +145,19 @@ We use the R [MOFA2](https://biofam.github.io/MOFA2/index.html) package
 for the analysis, and [install](https://biofam.github.io/MOFA2/installation.html) the corresponding dependencies.
 
 ```{r, message=FALSE, warning=FALSE}
-# For inter-operability between Python and R, and setting Python dependencies,
-# reticulate package is needed
-if(!require(reticulate)){
-    install.packages("https://cran.r-project.org/src/contrib/Archive/reticulate/reticulate_1.26.tar.gz",
-                     repos = NULL, type = "source")
-}
-
 if(!require(MOFA2)){
     BiocManager::install("MOFA2")
 }
 
+# For inter-operability between Python and R, and setting Python dependencies,
+# reticulate package is needed
+if(!require(reticulate)){
+    install.packages("reticulate")
+}
+
 reticulate::install_miniconda(force = TRUE)
 reticulate::use_miniconda(condaenv = "env1", required = FALSE)
-reticulate::py_install(packages = c("mofapy2"), pip = TRUE, python_version=3.6)
+reticulate::py_install(packages = c("mofapy2"), pip = TRUE)
 ```
 
 The `mae` object could be used straight to create the MOFA model. Yet, we transform 

--- a/23_multi-assay_analyses.Rmd
+++ b/23_multi-assay_analyses.Rmd
@@ -145,19 +145,20 @@ We use the R [MOFA2](https://biofam.github.io/MOFA2/index.html) package
 for the analysis, and [install](https://biofam.github.io/MOFA2/installation.html) the corresponding dependencies.
 
 ```{r, message=FALSE, warning=FALSE}
+# For inter-operability between Python and R, and setting Python dependencies,
+# reticulate package is needed
+if(!require(reticulate)){
+    install.packages("https://cran.r-project.org/src/contrib/Archive/reticulate/reticulate_1.26.tar.gz",
+                     repos = NULL, type = "source")
+}
+
 if(!require(MOFA2)){
     BiocManager::install("MOFA2")
 }
 
-# For inter-operability between Python and R, and setting Python dependencies,
-# reticulate package is needed
-if(!require(reticulate)){
-    install.packages("reticulate")
-}
-
 reticulate::install_miniconda(force = TRUE)
 reticulate::use_miniconda(condaenv = "env1", required = FALSE)
-reticulate::py_install(packages = c("mofapy2"), pip = TRUE)
+reticulate::py_install(packages = c("mofapy2"), pip = TRUE, python_version=3.6)
 ```
 
 The `mae` object could be used straight to create the MOFA model. Yet, we transform 


### PR DESCRIPTION
At the example of RDA, the calculation of variance explained for whole model and per each variable plus their corresponding p-values, is switched to using `anova.cca(rda, by="margin")`.