### PR TITLE
workflow fix; mofa --> python 3.6

### DIFF
--- a/23_multi-assay_analyses.Rmd
+++ b/23_multi-assay_analyses.Rmd
@@ -157,7 +157,7 @@ if(!require(reticulate)){
 
 reticulate::install_miniconda(force = TRUE)
 reticulate::use_miniconda(condaenv = "env1", required = FALSE)
-reticulate::py_install(packages = c("mofapy2"), pip = TRUE)
+reticulate::py_install(packages = c("mofapy2"), pip = TRUE, python_version=3.6)
 ```
 
 The `mae` object could be used straight to create the MOFA model. Yet, we transform 


### PR DESCRIPTION
Fixing workflow fails by instructing mofa installation at [Multi-assay analyses](https://github.com/microbiome/OMA/blob/master/23_multi-assay_analyses.Rmd#L160) to use python 3.6.
(related to discussion at #206 )