### PR TITLE
replace taxonomyTree and addTaxonomyTree with getHierarchyTree and addHierarchyTree

### DIFF
--- a/inst/pages/11_taxonomic_information.qmd
+++ b/inst/pages/11_taxonomic_information.qmd
@@ -118,17 +118,17 @@ specified taxonomic rank.
 head(getUniqueFeatures(tse, rank = "Phylum"))
 ```
 
-### Generate a taxonomic tree on the fly {#sec-fly-tree}
+### Generate a hierarchy tree on the fly {#sec-fly-tree}
 
-To create a taxonomic tree, `taxonomyTree` used the information and returns a
+To create a hierarchy tree, `getHierarchyTree` used the information and returns a
 `phylo` object. Duplicate information from the `rowData` is removed.
 
 ```{r}
-taxonomyTree(tse)
+getHierarchyTree(tse)
 ```
 
 ```{r}
-tse <- addTaxonomyTree(tse)
+tse <- addHierarchyTree(tse)
 tse
 ```
 

--- a/inst/pages/12_quality_control.qmd
+++ b/inst/pages/12_quality_control.qmd
@@ -186,7 +186,7 @@ top_phyla_mean <- getTopFeatures(altExp(tse,"Phylum"),
                              top=5L,
                              assay.type="counts")
 x <- unsplitByRanks(tse, ranks = taxonomyRanks(tse)[1:6])
-x <- addTaxonomyTree(x)
+x <- addHierarchyTree(x)
 ```
  
 After some preparation, the data is assembled and can be plotted with

--- a/inst/pages/98_exercises.qmd
+++ b/inst/pages/98_exercises.qmd
@@ -347,8 +347,8 @@ View(rowData(tse))
 
 5. Get the abundances for a specific feature, such as `OTU1810`, in all the
    samples. You can access feature-specific abundances for an _assay_ of your choice.  
-6. **Extra**: Create a taxonomy tree based on the taxonomy mappings with
-   `addTaxonomyTree` and display its content with `taxonomyTree` and `ggtree`.  
+6. **Extra**: Create a hierarchy tree based on the taxonomy mappings with
+   `addHierarchyTree` and display its content with `getHierarchyTree` and `ggtree`.  
 
 If you got stuck, you can look up chapters [@sec-datamanipulation]
 and [@sec-fly-tree] on how to pick specific abundances and generate


### PR DESCRIPTION
After PR renaming `taxonomyTree` and `addTaxonomyTree` to `getHierarchyTree` and `addHierarchyTree` in the mia package, this PR replace `taxonomyTree` and `addTaxonomyTree` with `getHierarchyTree` and `addHierarchyTree` in the OMA book.