### PR TITLE
replace cluster with addCluster

### DIFF
--- a/inst/pages/11_taxonomic_information.qmd
+++ b/inst/pages/11_taxonomic_information.qmd
@@ -219,7 +219,7 @@ tse <- transformAssay(tse, assay.type = "clr", method = "z",
                       MARGIN = "features")
 
 # Cluster (with euclidean distance) on the features of the z assay
-tse <- cluster(tse,
+tse <- addCluster(tse,
                assay.type = "z",
                clust.col = "hclustEuclidean",
 	       MARGIN = "features",
@@ -231,7 +231,7 @@ kendall_dissimilarity <- function(x) {
 }
 
 # Cluster (with Kendall dissimilarity) on the features of the z assay
-tse <- cluster(tse,
+tse <- addCluster(tse,
                assay.type = "z",
                clust.col = "hclustKendall",
        	       MARGIN = "features", 	       

--- a/inst/pages/24_clustering.qmd
+++ b/inst/pages/24_clustering.qmd
@@ -32,8 +32,8 @@ tse <- enterotype
 tse <- transformAssay(tse, method = "relabundance")
 ```
 
-The main focus in this example is to show how to use mia's `cluster` function to 
-cluster enterotype data. `cluster` function allows to choose a clustering algorithm and offers multiple parameters to shape the result. 
+The main focus in this example is to show how to use mia's `addCluster` function to 
+cluster enterotype data. `addCluster` function allows to choose a clustering algorithm and offers multiple parameters to shape the result. 
 
 In this example, HclustParam() parameter is chosen for hierarchical clustering. 
 HclustParam() parameter itself has parameters on its own 
@@ -45,7 +45,7 @@ A parameter is `MARGIN` defines whether to cluster features or samples .
 # Set the cut height to half of the dendrogram height
 
 # Save as an alternative experiment that contains clustering information
-altExp(tse, "hclust") <- cluster(tse, assay.type = "relabundance", 
+altExp(tse, "hclust") <- addCluster(tse, assay.type = "relabundance", 
                MARGIN = "samples", HclustParam())
 
 # The result can be found in 'clusters' column of colData
@@ -70,7 +70,7 @@ plotReducedDim(altExp(tse, "hclust"), "MDS", colour_by = "clusters")
 ## Hierarchical clustering
 
 The hierarchical clustering algorithm aims to find hierarchy between
-samples/features. There are to approaches: agglomerative ("bottom-up")
+samples/features. There are two approaches: agglomerative ("bottom-up")
 and divisive ("top-down"). In agglomerative approach, each observation is first in a unique cluster. The algorithm continues by agglomerating similar clusters. The divisive approach, instead, starts with one cluster that contains all observations. Clusters are split recursively into clusters that differ the most. The clustering ends when each cluster contains only one observation. In this algorithm, the similarity of two clusters is based on the distance
 between them.
 
@@ -94,7 +94,7 @@ of the column in the colData (default name is `clusters`).
 library(vegan)
 
 # Save another alternative experiment that contains full clustering information
-altExp(tse, "hclust_full") <- cluster(tse,
+altExp(tse, "hclust_full") <- addCluster(tse,
                assay.type = "relabundance",
                MARGIN = "samples",
                HclustParam(method = "complete",
@@ -200,7 +200,7 @@ In the example below, we calculate model fit using Laplace approximation. The cl
 # Run the model and calculates the most likely number of clusters from 1 to 7
 
 # Save as an alternative experiment that contains clustering information
-altExp(tse, "dmm") <- cluster(tse, name = "DMM", DmmParam(k = 1:7, type = "laplace"), 
+altExp(tse, "dmm") <- addCluster(tse, name = "DMM", DmmParam(k = 1:7, type = "laplace"), 
                    MARGIN = "samples", full = TRUE)
 ```
 
@@ -223,7 +223,7 @@ The best model can be confirmed with the following operation.
 bestFit <- metadata(altExp(tse, "dmm"))$DMM$dmm[[metadata(altExp(tse, "dmm"))$DMM$best]]
 bestFit
 ```
-The clusters for the best model are saved in the colData under 'cluster' column.
+The clusters for the best model are saved in the colData under 'clusters' column.
 
 ```{r dmm6}
 head(colData(altExp(tse, "dmm"))$clusters, 10)

--- a/inst/pages/add-comm-typing.Rmd
+++ b/inst/pages/add-comm-typing.Rmd
@@ -63,7 +63,7 @@ data, is to run community detection algorithms after building a
 graph. The following demonstration builds a graph based on the k
 nearest-neighbors and performs the community detection on the fly.
 
-Here, we will be using the `cluster` function with a graph-based clustering 
+Here, we will be using the `addCluster` function with a graph-based clustering 
 function, enabling the community detection task.
 
 The algorithm used is "short random walks" [@Pons2006]. The graph is
@@ -88,7 +88,7 @@ k <- c(2, 3, 5, 10)
 
 ClustAndPlot <- function(x) {
     # Add the clustering data from the short random walks algorithm to the TSE
-    tse <- cluster(tse, assay.type = "rclr", 
+    tse <- addCluster(tse, assay.type = "rclr", 
                    MARGIN = "col", NNGraphParam(k = x))
     
     # Plot the results of the clustering as a color for each sample
@@ -117,7 +117,7 @@ about Silhouettes read [@Rousseeuw1987].
 ```{r NNGraph2, message=FALSE, warning=FALSE}
 ClustDiagPlot <- function(x) {
   # Get the clustering results
-    tse <- cluster(tse, assay.type = "rclr", 
+    tse <- addCluster(tse, assay.type = "rclr", 
                    MARGIN = "col", NNGraphParam(k = x))
 
     # Compute the diagnostic info


### PR DESCRIPTION
After mia PR https://github.com/microbiome/mia/pull/502 renaming `cluster` to `addCluster` in the mia package, this PR replaces `cluster` with `addCluster` in the OMA book.