### PR TITLE
Update install_packages.R

### DIFF
--- a/install_packages.R
+++ b/install_packages.R
@@ -97,7 +97,17 @@ for(i in seq_along(chapter_pkgs)) {
     message("### CHAPTER: ", i, " ###")
     pkgsAvailable <- installed.packages()[, "Package"]
     pkgsToInstall <- setdiff(chapter_pkgs[[i]], c(pkgsAvailable, pkgs_github))
-    BiocManager::install(pkgsToInstall, update = FALSE, upgrade = FALSE, ask = FALSE, type = pkg_type)
+    #installs the devel versions of mia, miaViz and bluster
+    devel_pkgs <- c("mia", "miaViz", "bluster")
+    if (any(devel_pkgs %in% pkgsToInstall)) {
+        BiocManager::install(devel_pkgs[devel_pkgs %in% pkgsToInstall], update = FALSE, upgrade = FALSE, ask = FALSE, type = pkg_type, version = "devel")
+    }
+    #removes them from pkgsToInstall and then only installs if there are remaining packages
+    other_pkgs <- setdiff(pkgsToInstall, devel_pkgs)
+    
+    if (length(other_pkgs) > 0) {
+        BiocManager::install(other_pkgs, update = FALSE, upgrade = FALSE, ask = FALSE, type = pkg_type)
+    }
 }
 
 # Github packages

--- a/install_packages.R
+++ b/install_packages.R
@@ -97,10 +97,14 @@ for(i in seq_along(chapter_pkgs)) {
     message("### CHAPTER: ", i, " ###")
     pkgsAvailable <- installed.packages()[, "Package"]
     pkgsToInstall <- setdiff(chapter_pkgs[[i]], c(pkgsAvailable, pkgs_github))
+  
+    #removed installation step to make sure devel versions of following packages are installed
+  
     #installs the devel versions of mia, miaViz and bluster
     devel_pkgs <- c("mia", "miaViz", "bluster")
     if (any(devel_pkgs %in% pkgsToInstall)) {
-        BiocManager::install(devel_pkgs[devel_pkgs %in% pkgsToInstall], update = FALSE, upgrade = FALSE, ask = FALSE, type = pkg_type, version = "devel")
+        remotes::install_deps(devel_pkgs[devel_pkgs %in% pkgsToInstall], dependencies = TRUE,
+                          update = FALSE, upgrade = FALSE, ask = FALSE, type = pkg_type)
     }
     #removes them from pkgsToInstall and then only installs if there are remaining packages
     other_pkgs <- setdiff(pkgsToInstall, devel_pkgs)


### PR DESCRIPTION
I updated the for loop to install the devel version of specified packages as suggested in #361, It should be easy to update, if we ever need to add other devel versions of packages.

There's one minor possible issue which is that if the person already has these packages installed, it doesn't update to the devel version. Should I implement this or does this seem fine?