### PR TITLE
Issue 361 devel packages

### DIFF
--- a/install_packages.R
+++ b/install_packages.R
@@ -98,12 +98,13 @@ for (i in seq_along(chapter_pkgs)) {
   pkgsAvailable <- installed.packages()[, "Package"]
   pkgsToInstall <- setdiff(chapter_pkgs[[i]], c(pkgsAvailable, pkgs_github))
   
-  devel_pkgs <- c("mia", "miaViz", "bluster")
+  microbiome_devel_pkgs <- c("mia", "miaViz")
+  other_devel_pkgs <- c("bluster")
   
   # Check if any development packages are in pkgsToInstall
-  if (any(devel_pkgs %in% pkgsToInstall)) {
+  if (any(microbiome_devel_pkgs %in% pkgsToInstall)) {
     # Filter out only development packages from pkgsToInstall
-    devel_to_install <- devel_pkgs[devel_pkgs %in% pkgsToInstall]
+    devel_to_install <- microbiome_devel_pkgs[microbiome_devel_pkgs %in% pkgsToInstall]
     # Install development packages from GitHub
     for (pkg in devel_to_install) {
       github_url <- paste0("https://github.com/microbiome/", pkg, ".git")
@@ -115,7 +116,14 @@ for (i in seq_along(chapter_pkgs)) {
     pkgsToInstall <- setdiff(pkgsToInstall, devel_pkgs)
   }
   
-  # Install other packages (non-development)
+  # Install other development packages
+    for (pkg in other_devel_pkgs) {
+      BiocManager::install(pkgsToInstall, update = FALSE, upgrade = FALSE, 
+                           ask = FALSE, type = pkg_type, devel=TRUE)
+    }
+    pkgsToInstall <- setdiff(pkgsToInstall, other_devel_pkgs)
+  
+  # Install remaining packages (non-development)
   if (length(pkgsToInstall) > 0) {
     # Install non-development packages from CRAN or Bioconductor
     BiocManager::install(pkgsToInstall, update = FALSE, upgrade = FALSE, 

--- a/install_packages.R
+++ b/install_packages.R
@@ -93,12 +93,37 @@ chapter_pkgs <- list(all=pkgs_all)
 #  chapter_pkgs <- chapter_pkgs[ chapter_index ]
 #}
 
-for(i in seq_along(chapter_pkgs)) {
-    message("### CHAPTER: ", i, " ###")
-    pkgsAvailable <- installed.packages()[, "Package"]
-    pkgsToInstall <- setdiff(chapter_pkgs[[i]], c(pkgsAvailable, pkgs_github))
-    BiocManager::install(pkgsToInstall, update = FALSE, upgrade = FALSE, ask = FALSE, type = pkg_type)
+for (i in seq_along(chapter_pkgs)) {
+  message("### CHAPTER: ", i, " ###")
+  pkgsAvailable <- installed.packages()[, "Package"]
+  pkgsToInstall <- setdiff(chapter_pkgs[[i]], c(pkgsAvailable, pkgs_github))
+  
+  devel_pkgs <- c("mia", "miaViz", "bluster")
+  
+  # Check if any development packages are in pkgsToInstall
+  if (any(devel_pkgs %in% pkgsToInstall)) {
+    # Filter out only development packages from pkgsToInstall
+    devel_to_install <- devel_pkgs[devel_pkgs %in% pkgsToInstall]
+    # Install development packages from GitHub
+    for (pkg in devel_to_install) {
+      github_url <- paste0("https://github.com/microbiome/", pkg, ".git")
+      remotes::install_github(repo = github_url, 
+                              dependencies = TRUE, update = FALSE, 
+                              upgrade = FALSE, ask = FALSE, type = pkg_type)
+    }
+    # Remove installed development packages from pkgsToInstall
+    pkgsToInstall <- setdiff(pkgsToInstall, devel_pkgs)
+  }
+  
+  # Install other packages (non-development)
+  if (length(pkgsToInstall) > 0) {
+    # Install non-development packages from CRAN or Bioconductor
+    BiocManager::install(pkgsToInstall, update = FALSE, upgrade = FALSE, 
+                         ask = FALSE, type = pkg_type)
+  }
 }
+
+
 
 # Github packages
 devtools::install_github("microbiome/miaTime")

--- a/oma_packages.csv
+++ b/oma_packages.csv
@@ -86,3 +86,4 @@ utils
 datasets
 methods
 base
+kableExtra


### PR DESCRIPTION
This should fix #361 where the code installs github versions of the specified packages (mia and miaviz) and the devel version of bluster. It should be relatively easy to add or remove packages as well.