### PR TITLE
Fix: delete duplicate ggsignif library import

### DIFF
--- a/inst/pages/14_alpha_diversity.qmd
+++ b/inst/pages/14_alpha_diversity.qmd
@@ -119,7 +119,6 @@ It adds p-values to plot.
 library(ggsignif)
 library(ggplot2)
 library(patchwork)
-library(ggsignif)
 
 # Subsets the data. Takes only those samples that are from feces, skin, or tongue,
 # and creates data frame from the collected data


### PR DESCRIPTION
Ok, now it should be fixed and only the intended commit will be merged. Solves https://github.com/microbiome/OMA/pull/423.