### PR TITLE
replace getPrevalence and getPrevalentAbundance 

### DIFF
--- a/inst/pages/12_quality_control.qmd
+++ b/inst/pages/12_quality_control.qmd
@@ -74,7 +74,7 @@ threshold (`detection = 1/100` and `as_relative = TRUE`), can look
 like this. 
 
 ```{r exploration-prevalence}
-head(getPrevalence(tse, detection = 1/100, sort = TRUE, as_relative = TRUE))
+head(addPrevalence(tse, detection = 1/100, sort = TRUE, as_relative = TRUE))
 ```
 
 The function arguments `detection` and `as_relative` can also be used
@@ -84,7 +84,7 @@ threshold (`as_relative = FALSE`) at read count 1 (`detection = 1`) is
 accessed.
 
 ```{r concepts_prevalence2}
-head(getPrevalence(tse, detection = 1, sort = TRUE, assay.type = "counts",
+head(addPrevalence(tse, detection = 1, sort = TRUE, assay.type = "counts",
                    as_relative = FALSE))
 ```
 
@@ -96,7 +96,7 @@ If the output should be used for subsetting or storing the data in the
 To investigate microbiome prevalence at a selected taxonomic level, two 
 approaches are available.
 
-First the data can be agglomerated to the taxonomic level and `getPrevalence` 
+First the data can be agglomerated to the taxonomic level and `addPrevalence` 
 applied on the resulting object.
 
 ```{r}
@@ -104,7 +104,7 @@ applied on the resulting object.
 # to the altExp slot
 altExp(tse,"Phylum") <- mergeFeaturesByRank(tse, "Phylum")
 # Check prevalence for the Phylum abundance table from the altExp slot
-head(getPrevalence(altExp(tse,"Phylum"), detection = 1/100, sort = TRUE,
+head(addPrevalence(altExp(tse,"Phylum"), detection = 1/100, sort = TRUE,
                    assay.type = "counts", as_relative = TRUE))
 ```
 
@@ -112,12 +112,12 @@ Alternatively, the `rank` argument could be set to perform the
 agglomeration on the fly.
 
 ```{r}
-head(getPrevalence(tse, rank = "Phylum", detection = 1/100, sort = TRUE,
+head(addPrevalence(tse, rank = "Phylum", detection = 1/100, sort = TRUE,
                    assay.type = "counts", as_relative = TRUE))
 ```
 
 Note that, by default, `na.rm = TRUE` is used for agglomeration in
-`getPrevalence`, whereas the default for `mergeFeaturesByRank` is
+`addPrevalence`, whereas the default for `mergeFeaturesByRank` is
 `FALSE` to prevent accidental data loss.
 
 If you only need the names of the prevalent taxa, `getPrevalentFeatures`
@@ -135,7 +135,7 @@ Note that the `detection` and `prevalence` thresholds are not the same, since
 `detection` can be applied to relative counts or absolute counts depending on 
 whether `as_relative` is set `TRUE` or `FALSE`
 
-The function ‘getPrevalentAbundance’ can be used to check the total
+The function ‘addPrevalentAbundance’ can be used to check the total
 relative abundance of the prevalent taxa (between 0 and 1).
 
 ### Rare taxa
@@ -152,7 +152,7 @@ are stored in the `altExp` slot.
 
 ```{r}
 rowData(altExp(tse,"Phylum"))$prevalence <- 
-    getPrevalence(altExp(tse,"Phylum"), detection = 1/100, sort = FALSE,
+    addPrevalence(altExp(tse,"Phylum"), detection = 1/100, sort = FALSE,
                   assay.type = "counts", as_relative = TRUE)
 ```
 
@@ -173,7 +173,7 @@ altExps(tse) <-
    lapply(altExps(tse),
           function(y){
               rowData(y)$prevalence <- 
-                  getPrevalence(y, detection = 1/100, sort = FALSE,
+                  addPrevalence(y, detection = 1/100, sort = FALSE,
                                 assay.type = "counts", as_relative = TRUE)
               y
           })

--- a/inst/pages/98_exercises.qmd
+++ b/inst/pages/98_exercises.qmd
@@ -398,7 +398,7 @@ Useful functions: nrow, ncol, dim, summary, table, quantile, unique, addPerCellQ
 3. Report the thresholds and the dimensionality of the data before and after subsetting  
 4. Visualize prevalence  
 
-Useful functions: getPrevalence, getPrevalentFeatures, subsetByPrevalentFeatures
+Useful functions: addPrevalence, getPrevalentFeatures, subsetByPrevalentFeatures
 
 
 ### Data exploration


### PR DESCRIPTION
After mia PR https://github.com/microbiome/mia/pull/529 that renamed the following functions : 

- `getPrevalence` --> `addPrevalence`
- `getPrevalentAbundance` --> `addPrevalentAbundance`

This PR replaces these two functions in the OMA book.