### PR TITLE
Replace estimateDivergence with addDivergence

### DIFF
--- a/inst/pages/20_beta_diversity.qmd
+++ b/inst/pages/20_beta_diversity.qmd
@@ -87,12 +87,12 @@ tse$Group <- tse$SampleType == "Feces"
 
 Divergence measure refers to a difference in community composition
 between the given sample(s) and a reference sample. This can be
-evaluated with `estimateDivergence`. Reference and algorithm for the
+evaluated with `addDivergence`. Reference and algorithm for the
 calculation of divergence can be specified as `reference` and `FUN`,
 respectively.
 
 ```{r}
-tse <- mia::estimateDivergence(tse,
+tse <- mia::addDivergence(tse,
                                assay.type = "counts",
                                reference = "median",
                                FUN = vegan::vegdist)


### PR DESCRIPTION
After mia PR https://github.com/microbiome/mia/pull/531 that renamed the following function : 

- `estimateDivergence` --> `addDivergence`

This PR replaces `estimateDivergence` with `addDivergence` in the OMA book.