### PR TITLE
Fix: correct path to default.nix

### DIFF
--- a/.github/workflows/oma_nix_dev.yml
+++ b/.github/workflows/oma_nix_dev.yml
@@ -27,5 +27,5 @@ jobs:
               nix-build
          fi
 
-    - run: nix-store -qR --include-outputs $(nix-instantiate ../../default.nix) | cachix push oma
+    - run: nix-store -qR --include-outputs $(nix-instantiate ../cachix/default.nix) | cachix push oma
     - run: nix-shell --run "echo OK"


### PR DESCRIPTION
Should fix the workflow. `default.nix` path was incorrect.