### PR TITLE
Install dependencies with dependencies = TRUE

### DIFF
--- a/inst/pages/06_packages.qmd
+++ b/inst/pages/06_packages.qmd
@@ -24,10 +24,10 @@ that support this framework.
 
 ## Package installation
 
-You can install all packages that're required to run every example in this book via the following command:
+You can install all packages that are required to run every example in this book via the following command:
 
 ```{r eval=FALSE, message=FALSE}
-remotes::install_github('microbiome/OMA')
+remotes::install_github("microbiome/OMA", dependencies = TRUE)
 ```
 
 ### Installing specific packages {#sec-packages_specific}

--- a/inst/pages/06_packages.qmd
+++ b/inst/pages/06_packages.qmd
@@ -27,7 +27,7 @@ that support this framework.
 You can install all packages that are required to run every example in this book via the following command:
 
 ```{r eval=FALSE, message=FALSE}
-remotes::install_github("microbiome/OMA", dependencies = TRUE)
+remotes::install_github("microbiome/OMA", dependencies = TRUE, upgrade = TRUE)
 ```
 
 ### Installing specific packages {#sec-packages_specific}


### PR DESCRIPTION
Hi! According to OMA instructions for package installation, all the dependencies should be installed when running `remotes::install_github('microbiome/OMA')`. However, in that case we should set `dependencies = TRUE` because by default Suggests are not installed.

This example demonstrates how vegan was not installed together with OMA:

```
remove.packages("vegan")
Removing packages from '/Library/Frameworks/R.framework/Versions/4.4-x86_64/Resources/library'
(as 'lib' is unspecified)
```

You can see vegan was deleted

```
system.file(package = "vegan")
[1] ""
```

Now I install OMA from GitHub

```
remotes::install_github('microbiome/OMA')
Using GitHub PAT from the git credential store.
Downloading GitHub repo microbiome/OMA@HEAD
── R CMD build ─────────────────────────────────────────────────────────────────────
✔  checking for file '/private/var/folders/5y/2glwvl6j3yv459vzzlfh7j8h0000gn/T/Rtmp7CHQJ2/remotes563a2a719776/microbiome-OMA-e8b6e5b/DESCRIPTION' (644ms)
─  preparing 'OMA': (485ms)
✔  checking DESCRIPTION meta-information
─  checking for LF line-endings in source and make files and shell scripts (455ms)
─  checking for empty or unneeded directories
   Omitted 'LazyData' from DESCRIPTION
─  building 'OMA_0.98.21.tar.gz'
   
* installing *source* package 'OMA' ...
** using staged installation
** inst
** help
No man pages found in package  'OMA' 
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (OMA)
```

And vegan is still not there

```
system.file(package = "vegan")
[1] ""
```