### PR TITLE
Replace converters

### DIFF
--- a/inst/pages/04_containers.qmd
+++ b/inst/pages/04_containers.qmd
@@ -716,7 +716,7 @@ If the data has already been imported in R in another format, it
 can be readily converted into `TreeSE`, as shown in our next
 example. Note that similar conversion functions to
 `TreeSE` are available for multiple data formats via
-the `mia` package (see makeTreeSummarizedExperimentFrom* for phyloseq,
+the `mia` package (see convertFrom* for phyloseq,
 Biom, and DADA2).
 
 ```{r, message=FALSE}
@@ -730,7 +730,7 @@ GlobalPatterns_phyloseq
 
 ```{r, message=FALSE}
 # convert phyloseq to TSE
-GlobalPatterns_TSE <- makeTreeSummarizedExperimentFromPhyloseq(GlobalPatterns_phyloseq) 
+GlobalPatterns_TSE <- convertFromPhyloseq(GlobalPatterns_phyloseq) 
 GlobalPatterns_TSE
 ```
 
@@ -742,14 +742,14 @@ instance when additional methods are available for `phyloseq`.
 
 ```{r, message=FALSE}
 # convert TSE to phyloseq
-GlobalPatterns_phyloseq2 <- makePhyloseqFromTreeSummarizedExperiment(GlobalPatterns_TSE) 
+GlobalPatterns_phyloseq2 <- convertToPhyloseq(GlobalPatterns_TSE) 
 GlobalPatterns_phyloseq2
 ```
 
 Conversion is possible between other data formats. Interested readers can refer to the following functions:
 
-* [makeTreeSEFromDADA2](https://microbiome.github.io/mia/reference/makeTreeSEFromDADA2.html)  
-* [makeTreeSEFromBiom](https://microbiome.github.io/mia/reference/makeTreeSEFromBiom.html)  
+* [convertFromDADA2](https://microbiome.github.io/mia/reference/convertFromDADA2.html)  
+* [convertFromBIOM](https://microbiome.github.io/mia/reference/convertFromBIOM.html)  
 * [importMetaPhlAn](https://microbiome.github.io/mia/reference/importMetaPhlAn.html)  
 * [importQZA](https://microbiome.github.io/mia/reference/importQIIME2.html)
 

--- a/inst/pages/06_packages.qmd
+++ b/inst/pages/06_packages.qmd
@@ -95,7 +95,7 @@ The following DA methods support `(Tree)SummarizedExperiment`.
   site listed over 130 R packages for microbiome data science in2023. 
   Many of these are not in Bioconductor, or do not directly support the data containers 
   used in this book but can be often usedwith minor modifications. The phyloseq-based 
-  tools can be used byconverting the TreeSE data into phyloseq with `makePhyloseqFromTreeSummarizedExperiment`.
+  tools can be used by converting the TreeSE data into phyloseq with `convertToPhyloseq`.
 
 ### Open microbiome data 
 

--- a/inst/pages/98_exercises.qmd
+++ b/inst/pages/98_exercises.qmd
@@ -262,9 +262,9 @@ functions explained in chapter [@sec-import-from-file]. You can also check the
    [README](https://github.com/microbiome/data#training-microbiome-datasets)
    to import and construct datasets from there.  
 2. Import data by using mia. (functions: [importMetaPhlAn](https://microbiome.github.io/mia/reference/loadFromMetaphlan.html) | [importMothur](https://microbiome.github.io/mia/reference/importMothur.html) | 
-[importQIIME2](https://microbiome.github.io/mia/reference/importQIIME2.html) | [makeTreeSummarizedExperimentFromBiom](https://microbiome.github.io/mia/reference/makeTreeSEFromBiom.html) | 
-[makeTreeSummarizedExperimentFromDADA2](https://microbiome.github.io/mia/reference/makeTreeSEFromDADA2.html) ...)
-3. Try out conversions between TreeSE and phyloseq data containers ([makeTreeSummarizedExperimentFromPhyloseq](https://microbiome.github.io/mia/reference/makeTreeSEFromPhyloseq.html); [makephyloseqFromTreeSummarizedExperiment](https://microbiome.github.io/mia/reference/makePhyloseqFromTreeSE.html))  
+[importQIIME2](https://microbiome.github.io/mia/reference/importQIIME2.html) | [convertFromBIOM](https://microbiome.github.io/mia/reference/convertFromBIOM.html) | 
+[convertFromDADA2](https://microbiome.github.io/mia/reference/convertFromDADA2.html) ...)
+3. Try out conversions between TreeSE and phyloseq data containers ([convertFromPhyloseq](https://microbiome.github.io/mia/reference/convertFromPhyloseq.html); [convertToPhyloseq](https://microbiome.github.io/mia/reference/convertToPhyloseq.html))  
 
 
 ### Preliminary exploration


### PR DESCRIPTION
After mia PR https://github.com/microbiome/mia/pull/591 that made the following naming modifications:

`makeTreeSEFromDADA2` --> `convertFromDADA2`
`makeTreeSEFromBIOM` --> `convertFromBIOM`
`makeTreeSEFromPhyloseq` --> `convertFromPhyloseq`
`makePhyloseqFromTreeSE` --> `convertToPhyloseq`

This PR renames the converters in the OMA book.