### PR TITLE
update RDA exercise

### DIFF
--- a/inst/pages/exercises.qmd
+++ b/inst/pages/exercises.qmd
@@ -1110,9 +1110,8 @@ abundance assay (`formula = assay ~ Diet` and `assay.type = relabundance`) in
 terms of Bray-Curtis dissimilarity (`method = "bray"`).
 4. Extract the RDA dimensions from the appropriate reducedDim slot with
 `attr(reducedDim(tse, "RDA"), "rda)` and store it into `rda`.
-5. Extract the effect and significance of Diet on beta diversity by PERMANOVA with
-`attr(reducedDim(tse, "RDA"), "significance")` and store it into rda_info. 
-What do the results tell you about Diet?
+5. Extract the effect and significance of Diet on beta diversity with 
+attr(reducedDim(tse, "RDA"), "significance"). What do the results tell you about Diet?
 6. **Extra**: Check what other parameters are stored in the colData of
 peerj13075, add them to the formula (`formula = assay ~ Diet + ...`) of `getRDA`
 and proceed to see how that changes the results of PERMANOVA.

--- a/inst/pages/exercises.qmd
+++ b/inst/pages/exercises.qmd
@@ -1101,18 +1101,18 @@ variables (point 3). The results of RDA are usually assessed with PERMANOVA
 exercise. This is a relatively complex procedure, but the way this is broken
 down into steps below will hopefully make more sense.
 
-1. Import the mia and vegan packages, load any of the example data sets
+1. Import the mia package, load any of the example data sets
 mentioned in [@sec-example-data] with `data` and store it into a variable
 named `tse`.
 2. Transform the `counts` assay into relative abundances with `transformAssay`.
-3. Perform RDA with `getRDA` to see how much Diet can explain the relative
+3. Perform RDA with `addRDA` to see how much Diet can explain the relative
 abundance assay (`formula = assay ~ Diet` and `assay.type = relabundance`) in
 terms of Bray-Curtis dissimilarity (`method = "bray"`).
 4. Extract the RDA dimensions from the appropriate reducedDim slot with
 `attr(reducedDim(tse, "RDA"), "rda)` and store it into `rda`.
-5. Test the effect and significance of Diet on beta diversity by PERMANOVA with
-`vegan::anova.cca`. Feed this function with `rda` and set `by = "margin"` and
-`permutations = 99`, respectively. What do the results tell you about Diet?
+5. Extract the effect and significance of Diet on beta diversity by PERMANOVA with
+`attr(reducedDim(tse, "RDA"), "significance")` and store it into rda_info. 
+What do the results tell you about Diet?
 6. **Extra**: Check what other parameters are stored in the colData of
 peerj13075, add them to the formula (`formula = assay ~ Diet + ...`) of `getRDA`
 and proceed to see how that changes the results of PERMANOVA.
@@ -1129,7 +1129,7 @@ composition and various environmental or experimental factors within your
 dataset. You can refer to chapter [@sec-dbrda-workflow] for a step-by-step
 walkthrough, which may be simplified in the future.
 
-1. Import the mia and vegan packages, load any of the example data sets
+1. Import the mia package, load any of the example data sets
 mentioned in [@sec-example-data] with `data` and store it into a variable
 named `tse`.
    
@@ -1140,7 +1140,6 @@ named `tse`.
 #| code-summary: "Show solution"
 
 library(mia)
-library(vegan)
 
 data("GlobalPatterns", package = "mia") # Feel free to use any dataset
 tse <- GlobalPatterns

--- a/inst/pages/exercises.qmd
+++ b/inst/pages/exercises.qmd
@@ -1109,7 +1109,7 @@ named `tse`.
 abundance assay (`formula = assay ~ Diet` and `assay.type = relabundance`) in
 terms of Bray-Curtis dissimilarity (`method = "bray"`).
 4. Extract the RDA dimensions from the appropriate reducedDim slot with
-`attr(reducedDim(tse, "RDA"), "rda)` and store it into `rda`.
+`attr(reducedDim(tse, "RDA"), "rda)` and store it into a variable named `rda`.
 5. Extract the effect and significance of Diet on beta diversity with 
 attr(reducedDim(tse, "RDA"), "significance"). What do the results tell you about Diet?
 6. **Extra**: Check what other parameters are stored in the colData of


### PR DESCRIPTION
This PR updates the RDA exercise to not explicitly specify usage of `vegan::anova.cca` as this is already done in `mia::addRDA`