### PR TITLE
Temporarily disable certain section

### DIFF
--- a/inst/pages/mmuphin_meta_analysis.qmd
+++ b/inst/pages/mmuphin_meta_analysis.qmd
@@ -113,6 +113,13 @@ se_pathway <- sampleMetadata |>
 
 First, let's look into the relative abundance data.
 
+```{r}
+# Disable running the analysis temporaly. There is a problem in mia
+# agglomeration and curatedMetagenomicData
+# https://github.com/waldronlab/curatedMetagenomicData/pull/309
+knitr::opts_chunk$set(eval = FALSE)
+```
+
 ### Performing batch (study) effect adjustment with adjust_batch for relative abundance {#sec-batch-effect-adjustment}
 
 In this analysis, we are using two input files. The first input file is


### PR DESCRIPTION
Updated agglomeration in mia does not match with curatedMetagenomicData. That is why we have to disable this section until the fix is merged: https://github.com/waldronlab/curatedMetagenomicData/pull/309