### PR TITLE
Cross association function: fix deprecated arguments

### DIFF
--- a/inst/pages/cross_correlation.qmd
+++ b/inst/pages/cross_correlation.qmd
@@ -77,8 +77,8 @@ res <- getCrossAssociation(
     assay.type2 = "nmr",
     method = "spearman",
     test.signif = TRUE,
-    p_adj_threshold = NULL,
-    cor_threshold = NULL,
+    p.adj.threshold = NULL,
+    cor.threshold = NULL,
     # Remove when mia is fixed
     mode = "matrix",
     sort = TRUE,

--- a/oma_packages/oma_packages.csv
+++ b/oma_packages/oma_packages.csv
@@ -38,6 +38,7 @@ gtools
 igraph
 IntegratedLearner
 knitr
+limma
 Maaslin2
 maaslin3
 mediation
@@ -55,9 +56,9 @@ NbClust
 NetCoMi
 NMF
 patchwork
+philr
 phyloseq
 plotly
-plotROC
 purrr
 qgraph
 RColorBrewer
@@ -76,6 +77,7 @@ SPRING
 stats
 stringr
 SuperLearner
+tidySingleCellExperiment
 tidyverse
 topGO
 vegan


### PR DESCRIPTION
Some arguments are deprecated in `getCrossAssociation` function. I fixed it before it becomes a problem.