### PR TITLE
Fixed formatting issues and error in example solutions

### DIFF
--- a/inst/pages/.gitignore
+++ b/inst/pages/.gitignore
@@ -3,6 +3,7 @@
 *.log
 *.pdf
 *.png
+*.csv
 
 # Except .png files in images directory
 !figures/*.png

--- a/inst/pages/example_solutions.qmd
+++ b/inst/pages/example_solutions.qmd
@@ -319,16 +319,16 @@ p1 + p2
 
 # Subset the abundance table
 clr_matrix <- assay(tse, "clr")
-clr_matrix[1:10, 1:5]
+clr_matrix[1:100, 1:10]
 
-# Agglomerate data by Phylum rank
-tse_phylum <- agglomerateByRank(tse, rank = "Phylum")
+# Agglomerate data by ranks
+tse <- agglomerateByRanks(tse)
 
-# Apply transformation to Phylum data
-tse_phylum <- transformAssay(
-    tse_phylum, assay.type = "counts", method = "relabundance")
-tse_phylum <- transformAssay(
-    tse_phylum, assay.type = "counts", method = "clr", pseudocount = 1)
+# Apply transformations across altExp
+tse <- transformAssay(
+    tse, altexp = altExpNames(tse), assay.type = "counts", method = "relabundance")
+tse <- transformAssay(
+    tse, altexp = altExpNames(tse), assay.type = "counts", method = "clr", pseudocount = 1)
 
 # phiLR transformation
 tse <- transformAssay(

--- a/inst/pages/example_solutions.qmd
+++ b/inst/pages/example_solutions.qmd
@@ -322,13 +322,13 @@ clr_matrix <- assay(tse, "clr")
 clr_matrix[1:10, 1:5]
 
 # Agglomerate data by Phylum rank
-altExp(tse, "Phylum") <- agglomerateByRank(tse, rank = "Phylum")
+tse_phylum <- agglomerateByRank(tse, rank = "Phylum")
 
 # Apply transformation to Phylum data
-altExp(tse, "Phylum") <- transformAssay(
-    altExp(tse, "Phylum"), assay.type = "counts", method = "relabundance")
-altExp(tse, "Phylum") <- transformAssay(
-    altExp(tse, "Phylum"), assay.type = "counts", method = "clr", pseudocount = 1)
+tse_phylum <- transformAssay(
+    tse_phylum, assay.type = "counts", method = "relabundance")
+tse_phylum <- transformAssay(
+    tse_phylum, assay.type = "counts", method = "clr", pseudocount = 1)
 
 # phiLR transformation
 tse <- transformAssay(

--- a/inst/pages/example_solutions.qmd
+++ b/inst/pages/example_solutions.qmd
@@ -322,14 +322,13 @@ clr_matrix <- assay(tse, "clr")
 clr_matrix[1:10, 1:5]
 
 # Agglomerate data by Phylum rank
-tse_phylum <- agglomerateByRank(tse, rank = "Phylym")
+altExp(tse, "Phylum") <- agglomerateByRank(tse, rank = "Phylum")
 
 # Apply transformation to Phylum data
-tse_phylum <- altExp(tse, "Phylum")
-tse_phylum <- transformAssay(
-    tse_phylum, assay.type = "counts", method = "relabundance")
-tse_phylum <- transformAssay(
-    tse_phylum, assay.type = "counts", method = "clr", pseudocount = 1)
+altExp(tse, "Phylum") <- transformAssay(
+    altExp(tse, "Phylum"), assay.type = "counts", method = "relabundance")
+altExp(tse, "Phylum") <- transformAssay(
+    altExp(tse, "Phylum"), assay.type = "counts", method = "clr", pseudocount = 1)
 
 # phiLR transformation
 tse <- transformAssay(

--- a/inst/pages/transformation.qmd
+++ b/inst/pages/transformation.qmd
@@ -281,22 +281,21 @@ lots of zeroes?
 3. Transform the counts assay into relative abundances and store it into the
 `TreeSE` as an assay named `relabund`.
 
-3. Similarly, perform a CLR transformation on the counts assay with a
+4. Similarly, perform a CLR transformation on the counts assay with a
 `pseudocount` of 1 and add it to the `TreeSE` as a new assay.
 
-4. List the available assays by name.
+5. List the available assays by name.
 
-5. Visualize the CLR-transformed data with a histogram. Compare the distribution
+6. Visualize the CLR-transformed data with a histogram. Compare the distribution
 with distribution of counts data.
 
-6. Access the CLR-assay and store it to variable. Select a subset
+7. Access the CLR-assay and store it to variable. Select a subset
 of its first 100 features and 10 samples, and print the abundance table. Explore
 the data.
 
-6. Agglomerate the data with `agglomerateByRanks()` Transform data now with
-`altexp = altExpNames(tse)`.
+8. Agglomerate the data with `agglomerateByRanks()` then apply transformations to the stored alternative experiments created. Use the option `altexp = altExpnames(tse)`.
 
-6. If the data has phylogenetic tree, perform the phILR transformation. Where
+9. If the data has phylogenetic tree, perform the phILR transformation. Where
 the transformed data was stored? Compare the feature names with original data.
 Why the names differ?
 

--- a/inst/pages/visualization.qmd
+++ b/inst/pages/visualization.qmd
@@ -1,9 +1,9 @@
 # Visualization {#sec-viz-chapter}
 
 ```{r}
-#| label: "setup",
-#| echo = FALSE,
-#| results = "asis"
+#| label: "setup"
+#| echo: FALSE
+#| results: "asis"
 library(rebook)
 chapterPreamble()
 ```
@@ -35,7 +35,7 @@ includes the following packages:
 * _plotly_: animated and 3D plotting
 
 ```{r}
-#| include = FALSE
+#| include: FALSE
 library(ggplot2)
 theme_set(theme_classic())
 library(mia)
@@ -72,7 +72,7 @@ Such meta data can be directly plotted with the functions
 `plotRowData()` and `plotColData()`.
 
 ```{r}
-#| warning = FALSE
+#| warning: FALSE
 # obtain QC data
 tse <- addPerCellQC(tse)
 tse <- addPerFeatureQC(tse)
@@ -597,10 +597,10 @@ heatmap
 ```
 
 ```{r}
-#| label: "more_complex_heatmap2",
-#| fig.width = 10,
-#| fig.height = 8,
-#| eval = TRUE
+#| label: "more_complex_heatmap2"
+#| fig.width: 10
+#| fig.height: 8
+#| eval: TRUE
 library(patchwork)
 
 # Create layout
@@ -640,10 +640,10 @@ plot
 ```
 
 ```{r}
-#| label: "more_complex_heatmap3",
-#| fig.width = 10,
-#| fig.height = 8,
-#| eval = TRUE
+#| label: "more_complex_heatmap3"
+#| fig.width: 10
+#| fig.height: 8
+#| eval: TRUE
 # Create layout
 design <- c(
       patchwork::area(4, 1, 5, 1),

--- a/inst/pages/visualization.qmd
+++ b/inst/pages/visualization.qmd
@@ -2,7 +2,7 @@
 
 ```{r}
 #| label: "setup"
-#| echo: FALSE
+#| echo: false
 #| results: "asis"
 library(rebook)
 chapterPreamble()
@@ -35,7 +35,7 @@ includes the following packages:
 * _plotly_: animated and 3D plotting
 
 ```{r}
-#| include: FALSE
+#| include: false
 library(ggplot2)
 theme_set(theme_classic())
 library(mia)
@@ -72,7 +72,7 @@ Such meta data can be directly plotted with the functions
 `plotRowData()` and `plotColData()`.
 
 ```{r}
-#| warning: FALSE
+#| warning: false
 # obtain QC data
 tse <- addPerCellQC(tse)
 tse <- addPerFeatureQC(tse)
@@ -600,7 +600,7 @@ heatmap
 #| label: "more_complex_heatmap2"
 #| fig.width: 10
 #| fig.height: 8
-#| eval: TRUE
+#| eval: true 
 library(patchwork)
 
 # Create layout
@@ -643,7 +643,7 @@ plot
 #| label: "more_complex_heatmap3"
 #| fig.width: 10
 #| fig.height: 8
-#| eval: TRUE
+#| eval: true 
 # Create layout
 design <- c(
       patchwork::area(4, 1, 5, 1),


### PR DESCRIPTION
Added .csv into the .gitignore.

Fixed formatting issues that where not being parsed corrrectly. Should be inline with Quarto styling now.

Fixed typo and code in example_solutions.qmd

