### PR TITLE
Removed deprecated package reference from miaverse.qmd

### DIFF
--- a/inst/pages/miaverse.qmd
+++ b/inst/pages/miaverse.qmd
@@ -171,8 +171,6 @@ for data manipulation methods utilizing `tidy` paradigm
 
 ### Other relevant packages
 
-- [CBEA](https://bioconductor.org/packages/release/bioc/html/CBEA.html)
-[@Nguyen2022] for taxonomic enrichment analysis
 - [dar](https://www.bioconductor.org/packages/release/bioc/html/dar.html)
 for differential abundance testing
 - [LinDA](https://rdrr.io/cran/MicrobiomeStat/man/linda.html)[@Zhou2022]


### PR DESCRIPTION
In the miaverse chapter, I removed a reference to the package [CBEA](https://www.bioconductor.org/packages/release/bioc/html/CBEA.html), because it has been deprecated.