### PR TITLE
Move part introductions chapters to part prefaces

### DIFF
--- a/inst/assets/_book.yml
+++ b/inst/assets/_book.yml
@@ -34,9 +34,8 @@ book:
       chapters:
         - pages/taxonomy.qmd
         - pages/wrangling.qmd
-    - part: "QC & preprocessing"
+    - part: pages/preprocess.qmd
       chapters:
-        - pages/preprocess.qmd
         - pages/quality_control.qmd
         - pages/subsetting.qmd
         - pages/agglomeration.qmd
@@ -56,9 +55,8 @@ book:
       chapters:
         - pages/network_learning.qmd
         - pages/network_comparison.qmd
-    - part: "Multiomics"
+    - part: pages/multiomics.qmd
       chapters:
-        - pages/multiomics.qmd
         - pages/cross_correlation.qmd
         - pages/multiassay_ordination.qmd
         - pages/integrated_learner.qmd

--- a/inst/pages/multiomics.qmd
+++ b/inst/pages/multiomics.qmd
@@ -1,4 +1,4 @@
-# Multiomics {#sec-multi-omics}
+# Multi-omics {#sec-multi-omics}
 
 ```{r}
 #| label: setup

--- a/inst/pages/multiomics.qmd
+++ b/inst/pages/multiomics.qmd
@@ -1,4 +1,4 @@
-# Multi-omics {#sec-multi-omics}
+# Multiomics {#sec-multi-omics}
 
 ```{r}
 #| label: setup


### PR DESCRIPTION
Streamlined prefaces to parts so they are not separate numbered chapters. Based on this docs: https://quarto.org/docs/books/book-structure.html#parts-appendices