### PR TITLE
Fid tidy section

### DIFF
--- a/inst/pages/wrangling.qmd
+++ b/inst/pages/wrangling.qmd
@@ -267,7 +267,7 @@ by using tidy paradigm. For more information on library size, see
 #| label: tidy2
 
 tse %>%
-    join_features(features = rownames(tse)) %>%
+    join_features(features = rownames(tse), shape = "long") %>%
     group_by(.cell) %>%
     mutate(total_counts = sum(.abundance_counts)) %>%
     group_by(SampleType) %>%
@@ -289,7 +289,7 @@ library(ggplot2)
 tse %>%
     filter(SampleType == "Soil") %>%
     transformAssay(method = "clr", pseudocount = TRUE) %>%
-    join_features(features = rownames(tse)) %>%
+    join_features(features = rownames(tse), shape = "long") %>%
     ggplot(aes(x = .cell, y = .abundance_clr, fill = .cell)) +
     geom_boxplot()
 ```


### PR DESCRIPTION
The behavior of `join_features` has changed. It does not automatically return long-formatted table anymore.