### PR TITLE
feat(ci): add whitespace stripping to style workflow

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -58,6 +58,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-styler-
             ${{ runner.os }}-
+      - name: Strip trailing whitespace
+        run: |
+          git ls-files -z \
+            | grep -zE '\.(R|Rmd|qmd|Rmarkdown|Rnw|Rprofile)$' \
+            | xargs -0 -r sed -i 's/[[:blank:]]*$//'
       - name: Style
         run: |
           # Style only R files


### PR DESCRIPTION
If it was supported by RStudio, which is used by the majority of users, I think it's a good idea to include .editorconfig (https://editorconfig.org/).