### PR TITLE
Fix failing build

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,6 @@ Suggests:
     glue,
     gt,
     knitr,
-    Maaslin2,
     maaslin3,
     mediation,
     mia,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Suggests:
     glue,
     gt,
     knitr,
+    Maaslin2,
     maaslin3,
     mediation,
     mia,

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,13 @@ ARG BIOC_VERSION
 FROM bioconductor/bioconductor_docker:${BIOC_VERSION}
 COPY . /opt/pkg
 
-# Install book package 
-RUN Rscript -e 'repos <- BiocManager::repositories() ; remotes::install_local(path = "/opt/pkg/", repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE) ; sessioninfo::session_info(installed.packages()[,"Package"], include_base = TRUE)'
+# Install system Python, pip, and venv via Ubuntu's package manager – needed by mofa and book packages
+RUN apt-get update && apt-get install -y python3.12 python3.12-venv python3-pip && Rscript -e 'if(!requireNamespace("remotes", quietly=TRUE)) install.packages("remotes", repos="https://cloud.r-project.org"); remotes::install_local(path = "/opt/pkg/", dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE)' && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install mofapy2==0.7.3 --break-system-packages
+
+# Force R/reticulate to use this specific Python installation
+ENV RETICULATE_PYTHON="/usr/bin/python3.12"
 
 ## Build/install using same approach than BBS
 RUN R CMD INSTALL /opt/pkg

--- a/inst/pages/multiassay_ordination.qmd
+++ b/inst/pages/multiassay_ordination.qmd
@@ -139,7 +139,7 @@ model <- prepare_mofa(
 
 # Some systems may require the specification `use_basilisk = TRUE`
 # so it has been added to the following code
-model <- run_mofa(model, use_basilisk = TRUE)
+model <- run_mofa(model, use_basilisk = FALSE)
 ```
 
 The explained variance is visualized with the `plot_variance_explained()`

--- a/install_packages.R
+++ b/install_packages.R
@@ -1,72 +1,84 @@
-# The code adapted from Huber et al. 2023 
+# The code adapted from Huber et al. 2023
 # https://www.huber.embl.de/msmb/install_packages.R
 
 
 # Source location for the up-to-date package list:
 packages <- url("https://raw.githubusercontent.com/microbiome/OMA/devel/oma_packages/oma_packages.csv")
-#packages <- "oma_packages.csv"
+# packages <- "oma_packages.csv"
 # -------------------------------------------------------------------------------------------
 
 options(install.packages.check.source = "no")
 options(install.packages.compile.from.source = "never")
 Sys.setenv(R_REMOTES_UPGRADE = "never")
 
-pkg_type <- switch (Sys.info()["sysname"],
-                    "Linux" = "source", 
-                    "both")
+pkg_type <- switch(Sys.info()["sysname"],
+    "Linux" = "source",
+    "both"
+)
 
 ## Function to install packages one at a time with indication of time left
 ## Overall probably slower than install.packages if everything works
 ## but doesn't require downloading all packages first before trying to install any
 installer_with_progress <- function(pkgs) {
-    
-    if(length(pkgs) == 0) { invisible(return(NULL)) }
-    
+    if (length(pkgs) == 0) {
+        invisible(return(NULL))
+    }
+
     toInstall <- pkgs
-    bp <- progress::progress_bar$new(total = length(toInstall),
-                                     format = "Installed :current of :total (:percent ) - current package: :package",
-                                     show_after = 0,
-                                     clear = FALSE)
-    
+    bp <- progress::progress_bar$new(
+        total = length(toInstall),
+        format = "Installed :current of :total (:percent ) - current package: :package",
+        show_after = 0,
+        clear = FALSE
+    )
+
     length_prev <- length(toInstall)
     fail <- NULL
-    while(length(toInstall)) {
+    while (length(toInstall)) {
         pkg <- toInstall[1]
-        bp$tick(length_prev - length(toInstall),  tokens = list(package = pkg))
+        bp$tick(length_prev - length(toInstall), tokens = list(package = pkg))
         length_prev <- length(toInstall)
         tryCatch(
-            suppressMessages( BiocManager::install(pkg, quiet = TRUE, update = FALSE, ask = FALSE, type = "binary") ),
-            error = function(e) { fail <<- c(fail, pkg) },
-            warning = function(w) { fail <<- c(fail, pkg) },
+            suppressMessages(BiocManager::install(pkg, quiet = TRUE, update = FALSE, ask = FALSE, type = "binary")),
+            error = function(e) {
+                fail <<- c(fail, pkg)
+            },
+            warning = function(w) {
+                fail <<- c(fail, pkg)
+            },
             ## remove current package, otherwise we loop in event of failure
             ## update the list to reflect any dependencies that are now installed
-            finally = { toInstall <- setdiff(toInstall, installed.packages()[, "Package"]) }
+            finally = {
+                toInstall <- setdiff(toInstall, installed.packages()[, "Package"])
+            }
         )
     }
-    bp$tick(length_prev - length(toInstall),  tokens = list(package = "DONE!"))
-    
+    bp$tick(length_prev - length(toInstall), tokens = list(package = "DONE!"))
+
     return(fail)
 }
 
 ## these packages are needed prior to the installation
-if(!requireNamespace("BiocManager", quietly = TRUE)) {
-    install.packages(c('BiocManager'), repos = "https://cloud.r-project.org",
-                     quiet = TRUE, update = FALSE, ask = FALSE, type = pkg_type)
+if (!requireNamespace("BiocManager", quietly = TRUE)) {
+    install.packages(c("BiocManager"),
+        repos = "https://cloud.r-project.org",
+        quiet = TRUE, update = FALSE, ask = FALSE, type = pkg_type
+    )
 }
 ## update any existing packages
 BiocManager::install(update = TRUE, ask = FALSE)
 
-if(!requireNamespace("remotes", quietly = TRUE)) {
-    install.packages(c('remotes'), quiet = TRUE, update = FALSE, ask = FALSE, type = pkg_type)
+if (!requireNamespace("remotes", quietly = TRUE)) {
+    install.packages(c("remotes"), quiet = TRUE, update = FALSE, ask = FALSE, type = pkg_type)
 }
-if(!requireNamespace("magrittr", quietly = TRUE)) {
-    BiocManager::install('magrittr', quiet = TRUE, update = FALSE, ask = FALSE, type = pkg_type)
+if (!requireNamespace("magrittr", quietly = TRUE)) {
+    BiocManager::install("magrittr", quiet = TRUE, update = FALSE, ask = FALSE, type = pkg_type)
 }
 
 # ---------------------------
 
 ## list of packages required for each chapters
-pkgs_all <- read.table(packages)[,1]
+pkgs_all <- read.table(packages)[, 1]
 
 # Customization
 # Github packages must be installed separately
@@ -75,15 +87,15 @@ pkgs_github <- c("ggord")
 # ---------------------------
 
 # pkgs <- readRDS("oma_packages.rds") # Just do all at once
-chapter_pkgs <- list(all=pkgs_all)
+chapter_pkgs <- list(all = pkgs_all)
 # Can check later how packages can be splitted by chapter
-#chapter_pkgs <- split(pkgs$packages, pkgs$chapter)
+# chapter_pkgs <- split(pkgs$packages, pkgs$chapter)
 ### subset a selection of chapters if specified
-#if(exists('chapter_index') && is.numeric(chapter_index)) {
+# if(exists('chapter_index') && is.numeric(chapter_index)) {
 #  chapter_pkgs <- chapter_pkgs[ chapter_index ]
-#}
+# }
 
-for(i in seq_along(chapter_pkgs)) {
+for (i in seq_along(chapter_pkgs)) {
     message("### CHAPTER: ", i, " ###")
     pkgsAvailable <- installed.packages()[, "Package"]
     pkgsToInstall <- setdiff(chapter_pkgs[[i]], c(pkgsAvailable, pkgs_github))
@@ -98,13 +110,17 @@ devtools::install_github("fawda123/ggord")
 pkgsAvailable <- installed.packages()[, "Package"]
 pkgsNeeded <- unique(unlist(chapter_pkgs))
 pkgsToInstall <- setdiff(pkgsNeeded, pkgsAvailable)
-if(length(pkgsToInstall)) {
-    message("The following packages failed to install: \n",
-            paste(pkgsToInstall, collapse = ", "))
-    message("You can try re-running this installation script.\n",
-            "It will only try to install the missing packages.\n",
-            "This may make it easier to see the information R gives about why the installation failed.\n",
-            "Please contact microbiome@utu.fi for additional help.")
+if (length(pkgsToInstall)) {
+    message(
+        "The following packages failed to install: \n",
+        paste(pkgsToInstall, collapse = ", ")
+    )
+    message(
+        "You can try re-running this installation script.\n",
+        "It will only try to install the missing packages.\n",
+        "This may make it easier to see the information R gives about why the installation failed.\n",
+        "Please contact microbiome@utu.fi for additional help."
+    )
 }
 
 Sys.unsetenv("R_REMOTES_UPGRADE")

--- a/install_packages.R
+++ b/install_packages.R
@@ -82,7 +82,7 @@ pkgs_all <- read.table(packages)[, 1]
 
 # This will be installed manually later in this script
 # since it requires the latest devel update
-pkgs_all <- setdiff(pkgs_all, "Maaslin2") 
+pkgs_all <- setdiff(pkgs_all, "Maaslin2")
 
 # Customization
 # Github packages must be installed separately

--- a/install_packages.R
+++ b/install_packages.R
@@ -68,18 +68,9 @@ if(!requireNamespace("magrittr", quietly = TRUE)) {
 ## list of packages required for each chapters
 pkgs_all <- read.table(packages)[,1]
 
-# This will be installed manually later in this script
-# since it requires the latest devel update
-pkgs_all <- setdiff(pkgs_all, "Maaslin2") 
-
 # Customization
 # Github packages must be installed separately
-pkgs_github <- c("miaTime", "ggord")
-pkgs_nongithub <- setdiff(pkgs_all, pkgs_github)
-
-# Maaslin2 needs an update, see
-# https://forum.biobakery.org/t/xtfrm-error-with-maaslin2-default-example-in-r/5216/3
-remotes::install_github("biobakery/Maaslin2")
+pkgs_github <- c("ggord")
 
 # ---------------------------
 
@@ -100,7 +91,6 @@ for(i in seq_along(chapter_pkgs)) {
 }
 
 # Github packages
-devtools::install_github("microbiome/miaTime")
 devtools::install_github("fawda123/ggord")
 
 ## report packages no installed

--- a/install_packages.R
+++ b/install_packages.R
@@ -80,9 +80,18 @@ if (!requireNamespace("magrittr", quietly = TRUE)) {
 ## list of packages required for each chapters
 pkgs_all <- read.table(packages)[, 1]
 
+# This will be installed manually later in this script
+# since it requires the latest devel update
+pkgs_all <- setdiff(pkgs_all, "Maaslin2") 
+
 # Customization
 # Github packages must be installed separately
-pkgs_github <- c("ggord")
+pkgs_github <- c("miaTime", "ggord")
+pkgs_nongithub <- setdiff(pkgs_all, pkgs_github)
+
+# Maaslin2 needs an update, see
+# https://forum.biobakery.org/t/xtfrm-error-with-maaslin2-default-example-in-r/5216/3
+remotes::install_github("biobakery/Maaslin2")
 
 # ---------------------------
 
@@ -103,6 +112,7 @@ for (i in seq_along(chapter_pkgs)) {
 }
 
 # Github packages
+devtools::install_github("microbiome/miaTime")
 devtools::install_github("fawda123/ggord")
 
 ## report packages no installed

--- a/oma_packages/oma_packages.csv
+++ b/oma_packages/oma_packages.csv
@@ -17,6 +17,7 @@ ggtree
 glue
 gt
 knitr
+Maaslin2
 maaslin3
 mediation
 mia


### PR DESCRIPTION
Some points to consider:
1. Needed by MOFA: use Basilisk is FALSE for now as it tries to build python from scratch –-> memory intensive and can crash the container. Workaround installs python and sets up recticulate before building the book.
2. Maaslin2 might not be available on bioc ubuntu --> retained via gh