### PR TITLE
bump(deps): actions/cache@v4 to v6

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -51,7 +51,7 @@ jobs:
           )
         shell: Rscript {0}
       - name: Cache styler
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}


### PR DESCRIPTION
To avoid doing it manually, we can merge [this PR](https://github.com/microbiome/OMA/pull/865).