### PR TITLE
Remove deprecated workflow telemetry action

### DIFF
--- a/.github/workflows/biocbook.yml
+++ b/.github/workflows/biocbook.yml
@@ -18,9 +18,6 @@ jobs:
       - name: 🧾 Checkout repository
         uses: actions/checkout@v6
 
-      - name: ⏳ Collect Workflow Telemetry
-        uses: runforesight/workflow-telemetry-action@v2
-
       - name: 🧹 Clean up Docker environment
         run: |
           docker system prune --all --force --volumes


### PR DESCRIPTION
Closes #873

## Summary

- Remove the optional workflow telemetry action that still declares Node.js 20.
- Leave the remaining book-build workflow unchanged.

## Validation

- YAML parsed successfully with `yaml::read_yaml()`.
- `git diff --check` passed.
- Confirmed no telemetry references remain.
- `actionlint` was not available locally.