### PR TITLE
Document addMDS rarefaction feature retention

### DIFF
--- a/inst/pages/community_similarity.qmd
+++ b/inst/pages/community_similarity.qmd
@@ -505,6 +505,7 @@ tse <- addMDS(
     method = "euclidean",
     niter = 10, # Number of iterations
     sample = min(colSums(assay(tse, "counts"))), # Rarefaction depth
+    ntop = Inf, # Keep all features when determining rarefaction depth
     transf = clr, # Applied transformation
     replace = TRUE,
     name = "MDS_aitchison_rarefied"
@@ -530,17 +531,16 @@ wrap_plots(plots) +
     plot_layout(guides = "collect")
 ```
 
-`ntop` is an `addMDS()` option. Here it is set to total number of features in
-`GlobalPatterns` dataset so that they are not filtered. If `ntop` was not set
-to the total number of features, only the `ntop` features with highest variance
-would be used for dimensionality reduction and the other features would be
-filtered.
+`ntop` is an `addMDS()` option. Here it is set to `Inf` so that all features
+are retained when determining the rarefaction depth. If `ntop` were not set
+to include all features, only the features with the highest variance would be
+used for dimensionality reduction and the other features would be filtered.
 
 When rarefaction is not done, the `getDissimilarity()` utilizes
 `vegan::vegdist()` function while in rafection `vegan::avgdist()` is applied.
 The argument `sample` is set to the smallest metagenomic reads count across
-all samples. This ensures that no sample will be removed during the rarefaction
-process.
+all samples. Together with `ntop = Inf`, this ensures that no sample will be
+removed during the rarefaction process.
 
 The argument `niter` is by default set to 100 but 10 iterations is often
 sufficient for beta diversity calculations. To use transformations after the


### PR DESCRIPTION
## Summary
- retain all features when rarefying in the addMDS example
- explain the interaction between `ntop` and rarefaction depth

## Validation
- `git diff --check`
- affected R chunk parses successfully

Closes #824