### PR TITLE
Document swapping alternative experiments

### DIFF
--- a/inst/pages/containers.qmd
+++ b/inst/pages/containers.qmd
@@ -346,6 +346,24 @@ tse_single_sample <- tse[, 1]
 dim(altExp(tse_single_sample, "subsetted"))
 ```
 
+When an analysis expects the data of interest in the main experiment, an
+alternative experiment can be promoted temporarily with `swapAltExp()`.
+The previous main experiment is retained as an alternative experiment, so
+the operation can be reversed without losing any data.
+
+```{r}
+#| label: swap_altexp
+
+# Promote the alternative experiment for an analysis
+tse_swapped <- swapAltExp(tse, "subsetted", saved = "original")
+mainExpName(tse_swapped)
+altExpNames(tse_swapped)
+
+# Restore the original main experiment
+tse_restored <- swapAltExp(tse_swapped, "original", saved = "subsetted")
+mainExpName(tse_restored)
+```
+
 For more details on *altExp*, you can check the
 [introduction](https://bioconductor.org/packages/release/bioc/vignettes/SingleCellExperiment/inst/doc/intro.html)
 to the `r BiocStyle::Biocpkg("SingleCellExperiment")` package


### PR DESCRIPTION
## Summary
- document promoting an alternative experiment with `swapAltExp()`
- show how to restore the original main experiment without data loss

## Validation
- `git diff --check`
- affected R chunk parses successfully
- verified swap and restore round trip with SingleCellExperiment

Closes #811