### PR TITLE
Clarify exercise instructions across the book

### DIFF
--- a/inst/pages/community_similarity.qmd
+++ b/inst/pages/community_similarity.qmd
@@ -1100,8 +1100,8 @@ eigenvalues?
 
 6. Visualize the first two principal components.
 
-7. Explore `colData` and visualize the first two principal components again,
-now with samples colored based on a variable from the sample metadata. Can you
+7. Choose one sample-metadata variable from `colData` and visualize the first
+two principal components again, coloring samples by that variable. Can you
 observe any patterns?
 
 8. Visualize the PCA loadings for the two first components. Which features have
@@ -1127,16 +1127,16 @@ the `reducedDimNames()` -function. Is the PCoA reduced dimension available?
 without rarefaction. Do the plots look similar? What does rarefaction do, and
 what is it used for?
 
-**Exercise 3: Distance-based Redundancy Analsis (db-RDA)**
+**Exercise 3: Distance-based Redundancy Analysis (db-RDA)**
 
 1. Load any of the example datasets mentioned in [@sec-example-data].
 
-2. Explore `colData`. Select sample metadata variables and run distance-based
-redundancy analysis (db-RDA) on relative abundances with Bray-Curtis
-dissimilarity.
+2. Explore `colData`. Choose one or more relevant sample-metadata variables
+and run distance-based redundancy analysis (db-RDA) on relative abundances
+with Bray-Curtis dissimilarity.
 
 3. Explore the statistical significance of the results. Do the sample groups
-have homogenic variance? Is there a significant association between any
+have homogeneous variances? Is there a significant association between any
 variables and the microbial profile?
 
 4. Visualize the db-RDA results.

--- a/inst/pages/composition.qmd
+++ b/inst/pages/composition.qmd
@@ -181,9 +181,9 @@ microbial composition.
 4. Visualize community composition with a relative abundance bar plot. Which
 taxonomic features are most prevalent?
 
-5. Explore `colData`. Select the sample metadata variable and visualize the
-composition with a bar plot in respect to sample grouping. Does the community
-composition associate with the grouping?
+5. Choose one categorical variable from `colData` and use it to group a
+relative abundance bar plot. Does the community composition associate with
+the grouping?
 
 6. Normalize abundances to a standardized scale, i.e., calculate Z-scores.
 

--- a/inst/pages/machine_learning.qmd
+++ b/inst/pages/machine_learning.qmd
@@ -895,9 +895,9 @@ machine learning model utilizing multi-assay data.
 2. Observe `colData` and check that the metadata includes outcome variables that
 you want to model.
 
-3. Visualize the selected outcome variable with a histogram or a bar plot. What
-is the distribution? If the distribution is biased, how can this affect the
-training of the model?
+3. Visualize the selected outcome variable with a histogram if it is
+continuous, or a bar plot if it is categorical. What is the distribution? If
+the distribution is biased, how can this affect the training of the model?
 
 4. Apply CLR transformation.
 

--- a/inst/pages/machine_learning.qmd
+++ b/inst/pages/machine_learning.qmd
@@ -628,7 +628,7 @@ rf_senspec$model <- "rf"
 # xgb_senspec$model <- "XGBoost"
 
 # Combine model metrics
-senspec <- rbind(rf_senspec)#, xgb_senspec)
+senspec <- rbind(rf_senspec) # , xgb_senspec)
 
 # Inspect part of the output
 senspec |>

--- a/inst/pages/mediation.qmd
+++ b/inst/pages/mediation.qmd
@@ -326,8 +326,8 @@ If it does not, choose another dataset.
 
 5. Apply CLR transformation.
 
-6. Perform mediation analysis. Analyse genera as a mediators of treatment
-effect to the outcome.
+6. Perform mediation analysis. Analyze genera as mediators of the treatment
+effect on the outcome.
 
 7. Observe the results. Is there any taxonomic features that have significant
 causal effect (ACME)?

--- a/inst/pages/quality_control.qmd
+++ b/inst/pages/quality_control.qmd
@@ -526,7 +526,8 @@ samples?
 6. Visualize the library size distribution with histogram. Does the sampling
 depth differ a lot?
 
-7. Visualize categorical values in `colData` with a bar plot.
+7. Choose one categorical variable from `colData` (for example, `sex`) and
+visualize its value counts with `plotBarplot()`.
 
 8. Get the available taxonomy ranks in the data.
 

--- a/inst/pages/transformation.qmd
+++ b/inst/pages/transformation.qmd
@@ -298,7 +298,7 @@ Explore the data.
 
 8. Agglomerate the data with `agglomerateByRanks()` then apply transformations
 to the stored alternative experiments created. Use the option
-`altexp = altExpnames(tse)`.
+`altexp = altExpNames(tse)`.
 
 9. If the data has a phylogenetic tree, agglomerate the data to the family
 level and perform the phILR transformation. Where was the transformed data


### PR DESCRIPTION
## Summary
- clarify ambiguous exercise instructions for metadata, ordination, and model visualization
- correct the `altExpNames()` API spelling
- improve wording in mediation and QC exercises

## Validation
- `git diff --check`

Closes #858